### PR TITLE
docs: rewrite README, sync features and roadmap with shipped code

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,564 +3,152 @@
 </p>
 
 <h1 align="center">COSMQ</h1>
-<p align="center"><strong>Open-source Mobile Database Client</strong></p>
+<p align="center">Open-source mobile database client. Pronounced "cosmic".</p>
 
-<p align="center">
-  <strong>COSMQ</strong> (<strong>C</strong>lient <strong>O</strong>pen-<strong>S</strong>ource <strong>M</strong>obile <strong>Q</strong>uery) is a mobile database client for iOS and Android.
-</p>
-
-<p align="center"><em>Pronounced "cosmic"</em></p>
-
-Connect directly to PostgreSQL, MySQL/MariaDB, MongoDB, and SQLite databases using native TCP sockets, just like DBeaver or TablePlus, but for your phone.
-
-## Overview
-
-COSMQ is a full-featured database client that brings professional database management to your mobile device. Instead of relying on REST APIs, this app connects directly to your database servers using the native database wire protocols.
-
-**Key Highlights:**
-- 🔌 Direct TCP connection to databases (no intermediate API)
-- 🔒 Encrypted credential storage using device-native security
-- 📊 SQL query editor with results visualization
-- 🚀 Native iOS and Android support via Expo
-- ⚡ Built with modern React Native and TypeScript
-- 🌙 Dark theme optimized for SQL editors
+COSMQ (**C**lient **O**pen-**S**ource **M**obile **Q**uery) connects directly to PostgreSQL, MySQL/MariaDB, CockroachDB, MongoDB, and SQLite from iOS and Android. No proxy, no REST gateway — the app speaks each database's wire protocol over TCP.
 
 ## Screenshots
 
 <p align="center">
-  <img src="apps/landing/src/assets/screenshots/app/1.jpeg" width="200" alt="Connection List" />
-  <img src="apps/landing/src/assets/screenshots/app/2.jpeg" width="200" alt="Add Database" />
-  <img src="apps/landing/src/assets/screenshots/app/3.jpeg" width="200" alt="Query Editor" />
-  <img src="apps/landing/src/assets/screenshots/app/4.jpeg" width="200" alt="Results View" />
+  <img src="apps/landing/src/assets/screenshots/app/1.jpeg" width="200" alt="Connection list" />
+  <img src="apps/landing/src/assets/screenshots/app/2.jpeg" width="200" alt="New connection" />
+  <img src="apps/landing/src/assets/screenshots/app/3.jpeg" width="200" alt="Query editor" />
+  <img src="apps/landing/src/assets/screenshots/app/4.jpeg" width="200" alt="Results" />
 </p>
 
-## Architecture
+## Database support
 
-```
-┌─────────────────────────────────────────────────────────┐
-│                     React Native App                      │
-│                  (iOS / Android via Expo)                 │
-└─────────────────────────────────────────────────────────┘
-                            ↓
-                 ┌──────────────────────┐
-                 │  Connection Manager  │
-                 │   (Zustand Store)    │
-                 └──────────────────────┘
-                            ↓
-        ┌───────────────────┴───────────────────┐
-        ↓                                       ↓
-┌──────────────────┐              ┌──────────────────┐
-│ PostgreSQL v3    │              │  MySQL Protocol  │
-│   Implementation │              │  Implementation  │
-└──────────────────┘              └──────────────────┘
-        ↓                                       ↓
-        └───────────────────┬───────────────────┘
-                            ↓
-                  ┌──────────────────┐
-                  │   Protocol API   │
-                  │ (Unified Interf) │
-                  └──────────────────┘
-                            ↓
-                  ┌──────────────────┐
-                  │  TCP Socket      │
-                  │  (react-native   │
-                  │   -tcp-socket)   │
-                  └──────────────────┘
-                            ↓
-        ┌───────────────────┴───────────────────┐
-        ↓                                       ↓
-   PostgreSQL Server                    MySQL/MariaDB Server
-                            (MongoDB & SQLite also supported)
-```
-
-## Quick Start
-
-### Prerequisites
-
-- **Node.js**: 18+ (with bun package manager)
-- **Bun**: Latest version (`curl -fsSL https://bun.sh/install | bash`)
-- **Expo CLI**: Installed via bun (handled automatically)
-- **iOS/Android Development**: See [Expo documentation](https://docs.expo.dev)
-
-### Installation
-
-```bash
-cd apps/mobile
-
-# Install dependencies
-bun install
-
-# Generate TypeScript types for expo-router
-bun --filter @cosmq/mobile generate
-
-# Type check
-bun typecheck
-```
-
-### Running the App
-
-**Development Server:**
-```bash
-bun start
-```
-
-Then:
-- Press `i` for iOS simulator
-- Press `a` for Android emulator
-
-
-**Native Build (iOS):**
-```bash
-# First time setup
-bunx expo prebuild --platform ios --clean
-
-# Run on simulator
-bunx expo start --ios
-```
-
-**Native Build (Android):**
-```bash
-# First time setup
-bunx expo prebuild --platform android --clean
-
-# Run on emulator
-bunx expo start --android
-```
+| Engine | Auth | SSL/TLS | Schema browser | Transactions |
+|---|---|---|---|---|
+| PostgreSQL | Cleartext, MD5, SCRAM-SHA-256 | Yes | Yes | Yes |
+| MySQL / MariaDB | Native, Caching SHA2 | Yes | Yes | Yes |
+| CockroachDB | (PostgreSQL wire) | Yes | Yes | Yes |
+| MongoDB | SCRAM-SHA-1 | Yes | Yes (collections) | n/a |
+| SQLite | — | — | Yes | Yes |
 
 ## Features
 
-### Current (MVP)
+**Connections**
+- Save, edit, color-tag, and swipe-delete multiple connections
+- Passwords stored in the device keychain (`expo-secure-store`); metadata in `AsyncStorage`
+- Optional biometric app lock (Face ID, Touch ID, fingerprint, iris) with idle-timeout
+- Connection pool with idle eviction
 
-#### 1. **Connection Management**
-- Save multiple database connections locally
-- Secure storage of credentials (encrypted on device)
-- Quick connect/disconnect
-- Connection status indicators
-- Support for:
-  - PostgreSQL (all versions)
-  - MySQL / MariaDB
-  - MongoDB
-  - SQLite (Local)
-  - SSL/TLS connections
-  - Custom connection ports
-  - Multiple databases per server
+**Query editor**
+- Tokenized syntax highlighting
+- Context-aware autocomplete (knows you're after `FROM`, inside `SET`, etc.)
+- Quick-action keyword chips and starter templates (toggle in Settings)
+- Run, copy cell, copy all results
 
-#### 2. **Query Editor**
-- Syntax-highlighting SQL editor
-- Execute queries with keyboard shortcut
-- View execution time and row count
-- Clear, readable results table
+**Schema browser**
+- List tables and views, expand to see columns and types
 
-#### 3. **Results Viewer**
-- Horizontal scrollable table for wide datasets
-- Column names with data types
-- NULL value highlighting
-- Results exported as-is (ready for copying)
+**Transactions**
+- `BEGIN` / `COMMIT` / `ROLLBACK` from a banner above results
+- Optional auto-rollback timer (10–600s) so a forgotten transaction can't sit open
 
-#### 4. **Database Explorer** (Planned)
-- List databases/schemas
-- List tables with structure
-- View indexes and constraints
-- Quick table inspection
+**Safety**
+- Confirms before running `UPDATE`, `DELETE`, `DROP`, `TRUNCATE`, `ALTER`, `MERGE`, `REPLACE`
+- Configurable per-connection
 
-### Future Features
+**History & snippets**
+- Last 50 queries kept per device, deduped, searchable
+- Save named snippets to keep around
 
-- Cloud synchronization for connections
-- SSH Tunneling
-- Query history and favorites
-- Export results (CSV, JSON, SQL INSERT)
-- Database diff tool
-- Transaction support
-- Saved queries library
-- Query performance insights
+**Other**
+- Light and dark themes, JetBrainsMono editor font
+- Haptic feedback on success / error / transaction events
+- Reanimated v4 animations (pulse rings, fades, springs); honors Reduce Motion
 
-## Project Structure
-
-```
-mobile/
-├── app/                          # Expo Router screens (file-based routing)
-│   ├── _layout.tsx              # Root layout with providers
-│   ├── index.tsx                # Home screen (connections list)
-│   ├── connection/
-│   │   ├── new.tsx              # New connection form
-│   │   └── [id].tsx             # Connection details screen
-│   └── query/
-│       └── [connectionId].tsx    # SQL editor and results
-├── lib/
-│   ├── types.ts                 # TypeScript interfaces
-│   ├── tcp/
-│   │   └── socket.ts            # TCP socket wrapper (TcpClient class)
-│   ├── protocols/
-│   │   ├── postgres/            # PostgreSQL v3 wire protocol
-│   │   ├── mysql/               # MySQL wire protocol
-│   │   ├── mongodb/             # MongoDB driver (TCP + BSON)
-│   │   └── sqlite/              # SQLite adapter
-│   └── storage/
-│       └── connections.ts        # Secure credential storage
-├── stores/
-│   └── connection.ts             # Zustand connection state management
-├── app.json                       # Expo configuration
-├── package.json                   # Dependencies
-├── tsconfig.json                  # TypeScript configuration
-└── README.md                      # This file
-```
-
-## Technical Details
-
-### Database Connection Flow
-
-```
-User Action (Connect)
-    ↓
-useConnectionStore.connect()
-    ↓
-Create PostgresConnection instance
-    ↓
-TcpClient.connect() → Raw TCP socket
-    ↓
-PostgreSQL Startup Message
-    ↓
-Server: Auth Challenge (MD5, SCRAM-SHA-256, or Cleartext)
-    ↓
-Client: Password Message
-    ↓
-Server: Backend Key Data + Ready for Query
-    ↓
-Connection Ready
-```
-
-### Query Execution
-
-```
-User: Enters SQL and presses Run
-    ↓
-executeQuery(connectionId, sql)
-    ↓
-PostgresConnection.query(sql)
-    ↓
-Send Query Message (Describe + Execute)
-    ↓
-Receive: RowDescription (columns)
-    ↓
-Receive: DataRow messages (loop)
-    ↓
-Receive: CommandComplete
-    ↓
-Parse rows and return QueryResult
-    ↓
-Display results in table
-```
-
-### PostgreSQL Wire Protocol (v3)
-
-The implementation handles:
-
-1. **Startup (StartupMessage)**
-   - Protocol version: 3.0 (196608 in big-endian)
-   - Parameters: user, database, optional options
-
-2. **Authentication (AuthenticationXxx)**
-   - `OK` (0): No authentication
-   - `CleartextPassword` (3): Send password in plaintext
-   - `MD5Password` (5): MD5 hash of password + salt
-   - `SASL` (10): SCRAM-SHA-256 [Implemented, ready]
-
-3. **Query (Query)**
-   - Simple query string: `SELECT * FROM users;`
-   - Returns rows immediately
-
-4. **Response Messages**
-   - `RowDescription`: Column metadata (name, type OID)
-   - `DataRow`: Single row data with value lengths
-   - `CommandComplete`: Query finished with tag (SELECT, INSERT, etc.)
-   - `ErrorResponse`: Query error details
-
-### Type System
-
-All TypeScript code uses strict mode with full type safety:
-
-```typescript
-// Connection configuration
-export interface ConnectionConfig {
-  id: string;
-  name: string;
-  type: "postgres" | "mysql";
-  host: string;
-  port: number;
-  database: string;
-  username: string;
-  // password is stored separately in secure storage
-  ssl?: boolean;
-}
-
-// Query results
-export interface QueryResult {
-  columns: ColumnInfo[];
-  rows: Record<string, any>[];
-  rowCount: number;
-  command: string;
-  executionTime: number;
-}
-
-// Column metadata
-export interface ColumnInfo {
-  name: string;
-  type: string;
-  typeOID: number;
-  tableName?: string;
-}
-```
-
-### State Management (Zustand)
-
-The connection store manages all active database connections:
-
-```typescript
-const useConnectionStore = create<ConnectionStore>((set, get) => ({
-  // Map of connection ID → active connection instance
-  activeConnections: new Map<string, ActiveConnection>(),
-
-  // Connect to a database
-  connect: async (config: ConnectionConfig) => { /* ... */ },
-
-  // Execute SQL query on a connection
-  executeQuery: async (connectionId: string, sql: string) => Promise<QueryResult>,
-
-  // Cleanup when done
-  disconnect: async (connectionId: string) => { /* ... */ },
-  disconnectAll: async () => { /* ... */ },
-}));
-```
-
-### Secure Storage
-
-Passwords are stored separately from connection configs:
-
-```typescript
-// Config stored in regular storage (AsyncStorage)
-await AsyncStorage.setItem(`connection_${id}`, JSON.stringify(config));
-
-// Password stored in secure storage (encrypted on device)
-await SecureStore.setItemAsync(`password_${id}`, password);
-```
-
-This prevents accidental password exposure via debug logs or backups.
-
-## Development Workflow
-
-### Making Changes
-
-1. **UI Changes**: Edit files in `app/` directory (hot reload works)
-2. **Protocol Changes**: Modify `lib/protocols/postgres/`
-3. **State Changes**: Update `stores/connection.ts`
-4. **Type Changes**: Update `lib/types.ts`
-
-### Testing Changes
+## Quick start
 
 ```bash
-# Type check (catches errors before runtime)
-bun typecheck
-
-# Run on emulator (live reload)
-bunx expo start --ios    # iOS
-bunx expo start --android # Android
-```
-
-### Adding Dependencies
-
-```bash
-# Add a package
-bun add some-package
-
-# Add as dev dependency
-bun add -d some-package
-
-# Install all
 bun install
+bun --filter @cosmq/mobile dev
 ```
 
-## Database Support Matrix
+Then press `i` for iOS, `a` for Android, or `w` for web.
 
-### PostgreSQL ✅ Implemented
-
-| Feature | Status |
-|---------|--------|
-| Connection | ✅ Full support |
-| Authentication | ✅ Cleartext, MD5, SCRAM-SHA-256 ready |
-| SELECT queries | ✅ Fully working |
-| INSERT/UPDATE/DELETE | ✅ Fully working |
-| Transactions | ⏳ Ready to implement |
-| SSL/TLS | ✅ Supported |
-| Type OID mapping | ✅ Common types supported |
-
-### MySQL/MariaDB ✅ Implemented
-
-| Feature | Status |
-|---------|--------|
-| Connection | ✅ Full support |
-| Authentication | ✅ Native & Caching SHA2 |
-| SSL/TLS | ✅ Supported |
-
-### MongoDB / SQLite ✅ Implemented
-
-Both MongoDB (TCP/SCRAM-SHA-1) and SQLite (Local) are fully supported.
-
-## Configuration
-
-### `app.json` - Expo Configuration
-
-Key settings:
-- **SDK**: 54.0.0 (latest)
-- **Plugins**: expo-router, expo-secure-store
-- **Theme**: Dark theme colors (#16213e, #1a1a2e)
-- **TypedRoutes**: Enabled for type-safe routing
-
-### `tsconfig.json` - TypeScript
-
-- **Strict mode**: Enabled (no implicit any, etc.)
-- **Path aliases**: `@/*` for clean imports
-- **Target**: ES2020 with ES modules
-
-### `package.json` - Dependencies
-
-**Core:**
-- `expo` - Universal React Native framework
-- `expo-router` - File-based routing
-- `react-native` - Cross-platform UI
-- `react` - Component framework
-
-**Database:**
-- `react-native-tcp-socket` - Raw TCP connections
-
-**Storage:**
-- `expo-secure-store` - Encrypted credential storage
-
-**State & Data:**
-- `zustand` - Lightweight state management
-- `@tanstack/react-query` - Data fetching (ready to use)
-
-## Troubleshooting
-
-### Connection Fails with "Connection timeout"
-
-**Cause**: Server unreachable or firewall blocking
-**Solution**:
-1. Verify host and port
-2. Check if server is running: `telnet host port`
-3. Verify network connectivity (not on VPN?)
-4. Try without SSL first
-
-### "Buffer is not assignable to Uint8Array"
-
-**This is fixed**, but if you see it:
-- Ensure `@types/node` is in devDependencies
-- Run `bun install`
-- Run `bun typecheck` to verify
-
-### App crashes on connect
-
-**Check**:
-1. Connection credentials are correct
-2. Database name exists
-3. User has permission to connect
-4. Check device logs:
-   ```bash
-   # iOS
-   xcrun simctl launch booted com.yourapp
-
-   # Android
-   adb logcat | grep com.yourapp
-   ```
-
-### Query returns no results but should
-
-**Common issues**:
-1. Query is case-sensitive in some dialects
-2. User lacks SELECT permission on table
-3. Table doesn't exist in the selected database
-4. Check the error message in the app
-
-## Security Considerations
-
-⚠️ **Important**: This app connects to real database servers. Take security seriously:
-
-1. **Never share connection credentials** via screenshots, backups, etc.
-2. **Use SSL/TLS** for connections over untrusted networks
-3. **Avoid production databases** on shared devices
-4. **Clear connections** when handing device to someone else
-5. **Enable device lock** (biometric/passcode) - credentials are safer when device is locked
-6. **Use read-only database users** if connecting from shared networks
-
-## Performance Tips
-
-1. **Large result sets**: Pagination isn't implemented yet. Start with `LIMIT 100`
-2. **Slow queries**: Complex joins may timeout. Verify queries in a database client first
-3. **Mobile network**: Cellular connections may drop. Keep queries simple
-4. **Battery**: Extended connections drain battery. Use efficiently
-
-## Building for Production
+For native builds you'll want a development client:
 
 ```bash
-# Create production build for iOS
-bunx expo build:ios
+cd apps/mobile
+bunx expo prebuild --clean
+bunx expo run:ios       # or run:android
+```
 
-# Create production build for Android
-bunx expo build:android
+Production builds go through EAS:
 
-# Or submit directly to app stores
+```bash
 bunx eas build --platform ios
 bunx eas build --platform android
 ```
 
-See [Expo documentation](https://docs.expo.dev/build/setup/) for details.
+## Architecture
 
-## Future Roadmap
+```
+React Native (Expo) ──▶ Zustand connection store
+                              │
+                              ▼
+                       Protocol adapter
+            ┌──────────┬──────────┬──────────┬──────────┐
+            ▼          ▼          ▼          ▼          ▼
+        Postgres v3  MySQL    MongoDB   SQLite    (more)
+            │          │          │       (expo-sqlite)
+            └──────────┴──────────┘
+                       ▼
+              react-native-tcp-socket
+                       ▼
+                  Database server
+```
 
-### Phase 3: Enhanced Features
-- Database explorer with tree view
-- Query history with search
-- Saved queries with tags
-- Results export (CSV, JSON, SQL)
-- Query builder UI (drag-drop table joins)
+Each protocol implements the same `DatabaseConnection` interface (`connect`, `query`, `listTables`, `describeTable`, …) — the UI doesn't care which engine is on the other end.
 
-### Phase 4: Advanced
-- Query performance analysis
-- Transaction support with rollback UI
-- Database diff/schema comparison
-- Batch operations
-- Scripting support
+## Repo layout
+
+```
+apps/
+  mobile/        # Expo / React Native app
+    app/         # expo-router screens
+    components/  # UI + Tamagui-based primitives
+    lib/
+      protocols/ # postgres, mysql, mongodb, sqlite, mock
+      tcp/       # TCP + TLS socket wrapper
+      storage/   # connections, query history, snippets
+      app-lock.ts, pool.ts, haptics.ts, settings.ts, theme.ts
+    stores/      # Zustand stores (connection, settings)
+  landing/       # Marketing site
+packages/
+  tsconfig/      # Shared tsconfig
+```
+
+Monorepo runs on Bun + Turborepo. Lint/format with Biome.
+
+## Roadmap
+
+Not yet shipped:
+
+- SSH tunneling
+- Cloud sync for connections (encrypted, opt-in)
+- Export results to CSV / JSON / SQL `INSERT`
+- Result-set pagination for large queries
+- Schema diff between connections
+- Query performance / `EXPLAIN` viewer
+- Visual query builder
+
+## Security
+
+Treat this like any other database client.
+
+- Passwords live in the OS keychain, never in plain logs or snapshots.
+- Use SSL/TLS on anything past localhost.
+- Avoid pointing it at production from a shared device. Turn on the biometric app lock if you do.
+- Prefer read-only DB users when poking around on the road.
 
 ## Contributing
 
-Found a bug or have a feature idea?
-
-1. Check existing issues in the repo
-2. Create detailed bug reports with:
-   - Steps to reproduce
-   - Expected vs. actual behavior
-   - Device and OS version
-   - Connection type (PostgreSQL/MySQL)
+Issues and PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md). Security reports: see [SECURITY.md](SECURITY.md).
 
 ## License
 
-MIT - Use freely in personal and commercial projects
-
-## Resources
-
-- [Expo Documentation](https://docs.expo.dev)
-- [PostgreSQL Wire Protocol](https://www.postgresql.org/docs/current/protocol.html)
-- [MySQL Protocol](https://dev.mysql.com/doc/internals/en/client-server-protocol.html)
-- [React Native TCP Socket](https://github.com/rvagg/react-native-tcp-socket)
-- [React Native Documentation](https://reactnative.dev)
-
-## Support
-
-For issues:
-1. Check the troubleshooting section above
-2. Review device logs
-3. Try connecting with `psql` or `mysql` CLI to verify server is accessible
-4. Open an issue with detailed information
-
----
-
-**Made with ❤️ for database enthusiasts on mobile**
+[MIT](LICENSE).

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ bunx eas build --platform android
 
 ## Architecture
 
-```
+```text
 React Native (Expo) ──▶ Zustand connection store
                               │
                               ▼
@@ -106,7 +106,7 @@ Each protocol implements the same `DatabaseConnection` interface (`connect`, `qu
 
 ## Repo layout
 
-```
+```text
 apps/
   mobile/        # Expo / React Native app
     app/         # expo-router screens


### PR DESCRIPTION
## Summary

The README had drifted from the actual app. Several "planned" or "future" features have been shipped, a couple of database integrations weren't listed, and a few details were wrong. It also leaned hard into marketing-style prose. This rewrite replaces it with a tighter, accurate one (~150 lines, down from ~570).

### Roadmap items moved into Features (already shipped)
- **Database explorer** — `listTables` / `describeTable` for Postgres, MySQL, SQLite, MongoDB; expandable column panel in the query screen.
- **Query history** — `lib/storage/query-history.ts`, last 50 entries, deduped per connection.
- **Saved snippets** — `lib/storage/snippets.ts`, named, mutex-guarded.
- **Transaction support** — `BEGIN` / `COMMIT` / `ROLLBACK` banner with optional auto-rollback timer.

### Things the previous README didn't mention at all
- **CockroachDB** support (default port 26257, Postgres wire, transaction statements).
- **Biometric app lock** with idle-timeout (Face ID, Touch ID, fingerprint, iris).
- **Connection pool** with idle eviction (`lib/pool.ts`).
- **Dangerous-statement guard** (confirmation before UPDATE / DELETE / DROP / TRUNCATE / ALTER / MERGE / REPLACE).
- **Context-aware SQL autocomplete**, quick-action chips, starter templates.
- **Haptic feedback** on success / error / transaction events.
- **Light + dark themes** (was claimed dark-only).
- **Color-tagged connections**, swipe-to-delete.
- **Web target** via `react-native-web`.

### Corrections
- MongoDB auth: SCRAM-SHA-1 (the README claimed SCRAM-SHA-256).
- Build instructions: `expo run:ios` / `eas build` instead of the deprecated `expo build:ios`.
- Repo layout: now reflects the monorepo (`apps/mobile`, `apps/landing`, `packages/tsconfig`) instead of just the mobile folder.

### Cut
- Marketing emoji bullets, "Made with ❤️" footer, code-dump sections (type system, state management, secure storage), the "Performance Tips" advice column, and the DBeaver/TablePlus comparison repetition.

## Test plan
- [ ] README renders cleanly on github.com/arioberek/COSMQ
- [ ] All in-repo links resolve (CONTRIBUTING.md, SECURITY.md, LICENSE, screenshots, logo SVG)
- [ ] Database support matrix matches `lib/protocols/*` and `lib/types.ts` `DatabaseType`
- [ ] Quick-start commands run from a fresh clone (`bun install`, `bun --filter @cosmq/mobile dev`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured README with a more concise, user-focused layout.
  * Added comprehensive database support matrix detailing feature and authentication support across engines.
  * Updated quick start instructions with streamlined setup steps.
  * Added architecture overview and clearer repository layout guide.
  * Simplified sections for improved readability and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->