### PR TITLE
feat(mobile): mobile-first results view + visual query builder

### DIFF
--- a/apps/mobile/app/connection/[id].tsx
+++ b/apps/mobile/app/connection/[id].tsx
@@ -7,20 +7,32 @@ import { ScrollView, Text, useTheme, XStack, YStack } from "tamagui";
 import { DatabaseIcon } from "../../components/database-icon";
 import { Button, Dialog } from "../../components/ui";
 import { useHaptic } from "../../lib/haptics";
+import { safeBack } from "../../lib/navigation";
 import { deleteConnection, getConnectionWithPassword } from "../../lib/storage/connections";
 import { useConnectionStore } from "../../stores/connection";
 
 const InfoRow = ({ label, value }: { label: string; value: string }) => (
   <XStack
     justifyContent="space-between"
+    alignItems="center"
     paddingVertical="$sm"
+    gap="$md"
     borderBottomWidth={1}
     borderBottomColor="$borderColor"
   >
-    <Text color="$textSubtle" fontSize={14}>
+    <Text color="$textSubtle" fontSize={14} flexShrink={0}>
       {label}
     </Text>
-    <Text color="$color" fontSize={14} fontWeight="500">
+    <Text
+      color="$color"
+      fontSize={14}
+      fontWeight="500"
+      numberOfLines={1}
+      ellipsizeMode="middle"
+      flex={1}
+      textAlign="right"
+      selectable
+    >
       {value}
     </Text>
   </XStack>
@@ -82,7 +94,7 @@ export default function ConnectionDetailScreen() {
       await disconnect(id);
       await deleteConnection(id);
       await queryClient.invalidateQueries({ queryKey: ["connections"] });
-      router.back();
+      safeBack();
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Failed to delete connection");
       setShowErrorDialog(true);

--- a/apps/mobile/app/connection/new.tsx
+++ b/apps/mobile/app/connection/new.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import * as DocumentPicker from "expo-document-picker";
 import * as LegacyFileSystem from "expo-file-system/legacy";
-import { router, useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams } from "expo-router";
 import type { FC } from "react";
 import { useEffect, useState } from "react";
 import { KeyboardAvoidingView, Platform, Pressable, TextInput } from "react-native";
@@ -14,6 +14,7 @@ import MysqlIcon from "../../assets/icons/mysql.svg";
 import PostgresqlIcon from "../../assets/icons/postgresql.svg";
 import SqliteIcon from "../../assets/icons/sqlite.svg";
 import { Button, Dialog } from "../../components/ui";
+import { safeBack } from "../../lib/navigation";
 import {
   generateConnectionId,
   getConnectionWithPassword,
@@ -408,7 +409,7 @@ export default function NewConnectionScreen() {
         await queryClient.invalidateQueries({ queryKey: ["connection", editId] });
       }
 
-      router.back();
+      safeBack();
     } catch (error) {
       showAlert("Error", error instanceof Error ? error.message : "Failed to save connection");
     } finally {

--- a/apps/mobile/app/query/[connectionId].tsx
+++ b/apps/mobile/app/query/[connectionId].tsx
@@ -609,6 +609,9 @@ export default function QueryScreen() {
   const [query, setQuery] = useState("");
   const [editorMode, setEditorModeState] = useState<EditorMode>("editor");
   const [result, setResult] = useState<QueryResult | null>(null);
+  // Tracks the SQL string that produced the rendered `result` so ResultsView's
+  // prefs key stays stable while the editor buffer mutates after a run.
+  const [executedQuery, setExecutedQuery] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [executing, setExecuting] = useState(false);
   const [transactionState, setTransactionState] = useState<{
@@ -849,6 +852,7 @@ export default function QueryScreen() {
       await executeQuery(connectionId, transaction.begin);
       const queryResult = await executeQuery(connectionId, sql);
       setResult(queryResult);
+      setExecutedQuery(sql);
       setTransactionState({ active: true, statements: transaction });
       if (autoRollbackSeconds) {
         setTransactionDeadline(Date.now() + autoRollbackSeconds * 1000);
@@ -960,6 +964,7 @@ export default function QueryScreen() {
     try {
       const queryResult = await executeQuery(connectionId, trimmed);
       setResult(queryResult);
+      setExecutedQuery(trimmed);
       haptic.success();
       addToQueryHistory({
         query: trimmed,
@@ -1165,7 +1170,7 @@ export default function QueryScreen() {
           <ResultsView
             result={result}
             connectionId={connectionId}
-            query={query}
+            query={executedQuery}
             onCopyAll={copyAllResults}
           />
         )}

--- a/apps/mobile/app/query/[connectionId].tsx
+++ b/apps/mobile/app/query/[connectionId].tsx
@@ -11,11 +11,19 @@ import {
   TextInput,
   View,
 } from "react-native";
+import { BuilderView } from "../../components/builder/BuilderView";
+import { ResultsView } from "../../components/results/ResultsView";
 import { RunButton } from "../../components/run-button";
 import { Dialog } from "../../components/ui/Dialog";
 import { useTheme } from "../../hooks/useTheme";
+import { formatQueryError } from "../../lib/errors";
 import { useHaptic } from "../../lib/haptics";
 import { normalizeAutoRollbackSeconds } from "../../lib/settings";
+import {
+  type EditorMode,
+  getEditorMode,
+  setEditorMode,
+} from "../../lib/storage/results-prefs";
 import {
   addToQueryHistory,
   getQueryHistory,
@@ -599,6 +607,7 @@ export default function QueryScreen() {
   const haptic = useHaptic();
   const { connectionId } = useLocalSearchParams<{ connectionId: string }>();
   const [query, setQuery] = useState("");
+  const [editorMode, setEditorModeState] = useState<EditorMode>("editor");
   const [result, setResult] = useState<QueryResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [executing, setExecuting] = useState(false);
@@ -647,21 +656,6 @@ export default function QueryScreen() {
     ? `Txn ${formatCountdown(transactionTimeLeft)}`
     : "Txn Manual";
 
-  const columnWidths = useMemo(
-    () => (result ? getColumnWidths(result.columns, result.rows) : []),
-    [result],
-  );
-
-  const copyCellValue = useCallback(
-    async (value: unknown) => {
-      const str =
-        value === null ? "null" : typeof value === "object" ? JSON.stringify(value) : String(value);
-      await Clipboard.setStringAsync(str);
-      haptic.light();
-    },
-    [haptic],
-  );
-
   const copyAllResults = async () => {
     if (!result) return;
     const header = result.columns.map((c) => c.name).join("\t");
@@ -685,18 +679,13 @@ export default function QueryScreen() {
   };
 
   const loadTables = async () => {
-    if (!connection?.instance) {
-      console.warn("[loadTables] No connection instance");
-      return;
-    }
+    if (!connection?.instance) return;
     setLoadingTables(true);
     try {
       const tableList = await connection.instance.listTables();
-      console.log("[loadTables] Loaded tables:", tableList.length);
       setTables(tableList);
     } catch (err) {
-      console.error("[loadTables] Error:", err);
-      showAlert("Couldn't load tables", err instanceof Error ? err.message : "Unknown error");
+      showAlert("Couldn't load tables", formatQueryError(err, connection.config.type));
     } finally {
       setLoadingTables(false);
     }
@@ -721,8 +710,8 @@ export default function QueryScreen() {
       const columns = await connection.instance.describeTable(schema, tableName);
       setTableColumns((prev) => ({ ...prev, [tableName]: columns }));
       setExpandedTable(tableName);
-    } catch {
-      showAlert("Couldn't load columns", `Failed to load columns for ${tableName}.`);
+    } catch (err) {
+      showAlert("Couldn't load columns", formatQueryError(err, connection.config.type));
     }
   };
 
@@ -925,6 +914,27 @@ export default function QueryScreen() {
     autoRollbackTriggered.current = false;
   }, [transactionState.active, settings.autoRollbackEnabled, settings.autoRollbackSeconds]);
 
+  useEffect(() => {
+    if (!connectionId) return;
+    let cancelled = false;
+    getEditorMode(connectionId).then((mode) => {
+      if (!cancelled && mode) setEditorModeState(mode);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [connectionId]);
+
+  const handleEditorModeChange = useCallback(
+    (next: EditorMode) => {
+      if (!connectionId) return;
+      setEditorModeState(next);
+      haptic.light();
+      setEditorMode(connectionId, next).catch(() => {});
+    },
+    [connectionId, haptic],
+  );
+
   const handleExecute = async () => {
     const trimmed = query.trim();
     if (!connectionId || !trimmed) return;
@@ -975,16 +985,47 @@ export default function QueryScreen() {
   return (
     <View style={styles.container}>
       <View style={styles.editorContainer}>
-        <SqlEditor
-          value={query}
-          onChangeText={setQuery}
-          placeholder="Type SQL or tap a template..."
-          enableAutocomplete={settings.enableAutocomplete}
-          showTemplates={settings.showSqlTemplates}
-          showQuickActions={settings.showQuickActions}
-          styles={styles}
-          theme={theme}
-        />
+        <View style={styles.modeToggleRow}>
+          {(["editor", "builder"] as const).map((m) => {
+            const active = editorMode === m;
+            return (
+              <Pressable
+                key={m}
+                style={[styles.modeToggleChip, active && styles.modeToggleChipActive]}
+                onPress={() => handleEditorModeChange(m)}
+              >
+                <Text
+                  style={[styles.modeToggleText, active && styles.modeToggleTextActive]}
+                >
+                  {m === "editor" ? "Editor" : "Builder"}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        {editorMode === "editor" ? (
+          <SqlEditor
+            value={query}
+            onChangeText={setQuery}
+            placeholder="Type SQL or tap a template..."
+            enableAutocomplete={settings.enableAutocomplete}
+            showTemplates={settings.showSqlTemplates}
+            showQuickActions={settings.showQuickActions}
+            styles={styles}
+            theme={theme}
+          />
+        ) : connectionId && connection?.instance ? (
+          <View style={styles.builderContainer}>
+            <BuilderView
+              connectionId={connectionId}
+              type={connection.config.type}
+              instance={connection.instance}
+              onQueryChange={setQuery}
+            />
+          </View>
+        ) : null}
+
         <View style={styles.runRow}>
           <View style={styles.runRowLeft}>
             <Pressable
@@ -1034,8 +1075,8 @@ export default function QueryScreen() {
               {tables.length === 0 && !loadingTables && (
                 <Text style={styles.tablesEmpty}>No tables found</Text>
               )}
-              {tables.map((table) => (
-                <View key={`${table.schema}-${table.name}`}>
+              {tables.map((table, index) => (
+                <View key={`${table.schema ?? "_"}-${table.name}-${table.type ?? "_"}-${index}`}>
                   <Pressable
                     style={styles.tableItem}
                     onPress={() => loadTableColumns(table.name)}
@@ -1120,118 +1161,13 @@ export default function QueryScreen() {
           </View>
         )}
 
-        {result && (
-          <>
-            {/* ── Meta bar ── */}
-            {(() => {
-              const cmd = result.command.trim().toUpperCase();
-              return (
-                <View style={styles.resultsMeta}>
-                  <View style={styles.metaStats}>
-                    <Text style={styles.metaCount}>{result.rowCount.toLocaleString()}</Text>
-                    <Text style={styles.metaLabel}>
-                      {cmd.startsWith("SELECT") ? " rows" : " affected"}
-                    </Text>
-                    <Text style={styles.metaSep}>·</Text>
-                    <Text style={styles.metaTime}>{result.executionTime}ms</Text>
-                  </View>
-                  <View style={styles.metaActions}>
-                    {result.columns.length > 0 && (
-                      <Pressable style={styles.copyAllButton} onPress={copyAllResults}>
-                        <Text style={styles.copyAllText}>Copy all</Text>
-                      </Pressable>
-                    )}
-                    <View style={styles.commandBadge}>
-                      <Text style={styles.commandBadgeText}>{cmd.split(" ")[0]}</Text>
-                    </View>
-                  </View>
-                </View>
-              );
-            })()}
-
-            {/* ── Table ── */}
-            {result.columns.length > 0 && (
-              <ScrollView
-                horizontal
-                style={styles.tableContainer}
-                showsHorizontalScrollIndicator={false}
-              >
-                <ScrollView
-                  nestedScrollEnabled
-                  showsVerticalScrollIndicator={false}
-                  style={styles.tableRows}
-                >
-                  {/* Header row */}
-                  <View style={styles.tableHeader}>
-                    {result.columns.map((col, ci) => (
-                      <View
-                        key={`header-${col.name}`}
-                        style={[styles.headerCell, { width: columnWidths[ci] }]}
-                      >
-                        <Text style={styles.headerText} numberOfLines={1}>
-                          {col.name}
-                        </Text>
-                        {col.type ? (
-                          <Text style={styles.typeText} numberOfLines={1}>
-                            {col.type.toLowerCase()}
-                          </Text>
-                        ) : null}
-                      </View>
-                    ))}
-                  </View>
-
-                  {/* Data rows or empty */}
-                  {result.rows.length === 0 ? (
-                    <View style={styles.emptyResult}>
-                      <Text style={styles.emptyResultText}>No rows returned</Text>
-                    </View>
-                  ) : (
-                    result.rows.map((item, index) => (
-                      <View
-                        key={`row-${index}`}
-                        style={[styles.tableRow, index % 2 === 1 && styles.tableRowAlt]}
-                      >
-                        {result.columns.map((col, ci) => {
-                          const val = item[col.name];
-                          return (
-                            <Pressable
-                              key={`cell-${col.name}`}
-                              style={({ pressed }) => [
-                                styles.cell,
-                                { width: columnWidths[ci] },
-                                pressed && styles.cellPressed,
-                              ]}
-                              onPress={() => copyCellValue(val)}
-                            >
-                              {val === null ? (
-                                <Text style={styles.nullText}>null</Text>
-                              ) : (
-                                <Text style={styles.cellText} numberOfLines={3}>
-                                  {typeof val === "object" ? JSON.stringify(val) : String(val)}
-                                </Text>
-                              )}
-                            </Pressable>
-                          );
-                        })}
-                      </View>
-                    ))
-                  )}
-                </ScrollView>
-              </ScrollView>
-            )}
-
-            {/* ── Non-SELECT success state (DDL / DML) ── */}
-            {result.columns.length === 0 && (
-              <View style={styles.commandResult}>
-                <Text style={styles.commandResultCheck}>✓</Text>
-                <Text style={styles.commandResultText}>
-                  {result.rowCount > 0
-                    ? `${result.rowCount.toLocaleString()} row${result.rowCount === 1 ? "" : "s"} affected`
-                    : "Query executed successfully"}
-                </Text>
-              </View>
-            )}
-          </>
+        {result && connectionId && (
+          <ResultsView
+            result={result}
+            connectionId={connectionId}
+            query={query}
+            onCopyAll={copyAllResults}
+          />
         )}
 
         {!result && !error && !executing && (
@@ -1461,6 +1397,39 @@ const createStyles = (theme: Theme) =>
       padding: 16,
       borderBottomWidth: 1,
       borderBottomColor: theme.colors.border,
+    },
+    modeToggleRow: {
+      flexDirection: "row",
+      gap: 4,
+      backgroundColor: theme.colors.surfaceMuted,
+      padding: 3,
+      borderRadius: 10,
+      alignSelf: "flex-start",
+      marginBottom: 10,
+    },
+    modeToggleChip: {
+      paddingHorizontal: 14,
+      paddingVertical: 6,
+      borderRadius: 8,
+    },
+    modeToggleChipActive: {
+      backgroundColor: theme.colors.surface,
+    },
+    modeToggleText: {
+      color: theme.colors.textSubtle,
+      fontSize: 12,
+      fontWeight: "600",
+    },
+    modeToggleTextActive: {
+      color: theme.colors.text,
+    },
+    builderContainer: {
+      height: 380,
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      padding: 12,
+      backgroundColor: theme.colors.surface,
     },
     sqlEditorContainer: {
       position: "relative",

--- a/apps/mobile/app/query/[connectionId].tsx
+++ b/apps/mobile/app/query/[connectionId].tsx
@@ -20,15 +20,11 @@ import { formatQueryError } from "../../lib/errors";
 import { useHaptic } from "../../lib/haptics";
 import { normalizeAutoRollbackSeconds } from "../../lib/settings";
 import {
-  type EditorMode,
-  getEditorMode,
-  setEditorMode,
-} from "../../lib/storage/results-prefs";
-import {
   addToQueryHistory,
   getQueryHistory,
   type QueryHistoryItem,
 } from "../../lib/storage/query-history";
+import { type EditorMode, getEditorMode, setEditorMode } from "../../lib/storage/results-prefs";
 import {
   deleteSnippet,
   getSnippets,
@@ -999,9 +995,7 @@ export default function QueryScreen() {
                 style={[styles.modeToggleChip, active && styles.modeToggleChipActive]}
                 onPress={() => handleEditorModeChange(m)}
               >
-                <Text
-                  style={[styles.modeToggleText, active && styles.modeToggleTextActive]}
-                >
+                <Text style={[styles.modeToggleText, active && styles.modeToggleTextActive]}>
                   {m === "editor" ? "Editor" : "Builder"}
                 </Text>
               </Pressable>

--- a/apps/mobile/components/builder/BuilderSection.tsx
+++ b/apps/mobile/components/builder/BuilderSection.tsx
@@ -1,0 +1,63 @@
+import { Ionicons } from "@expo/vector-icons";
+import { memo } from "react";
+import { Pressable } from "react-native";
+import { Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+
+type BuilderSectionProps = {
+  title: string;
+  hint?: string;
+  onAdd?: () => void;
+  addLabel?: string;
+  children: React.ReactNode;
+};
+
+export const BuilderSection = memo(function BuilderSection({
+  title,
+  hint,
+  onAdd,
+  addLabel,
+  children,
+}: BuilderSectionProps) {
+  const tamagui = useTamaguiTheme();
+  return (
+    <YStack gap={6}>
+      <XStack alignItems="center" justifyContent="space-between">
+        <XStack alignItems="baseline" gap={6}>
+          <Text
+            color="$placeholderColor"
+            fontSize={11}
+            fontFamily="$mono"
+            textTransform="uppercase"
+            letterSpacing={0.5}
+            fontWeight="700"
+          >
+            {title}
+          </Text>
+          {hint ? (
+            <Text color="$placeholderColor" fontSize={11}>
+              {hint}
+            </Text>
+          ) : null}
+        </XStack>
+        {onAdd ? (
+          <Pressable hitSlop={8} onPress={onAdd}>
+            <XStack
+              alignItems="center"
+              gap={3}
+              paddingHorizontal={8}
+              paddingVertical={4}
+              borderRadius={999}
+              backgroundColor="$primaryMuted"
+            >
+              <Ionicons name="add" size={12} color={tamagui.primary.val} />
+              <Text color="$primary" fontSize={11} fontWeight="600">
+                {addLabel ?? "Add"}
+              </Text>
+            </XStack>
+          </Pressable>
+        ) : null}
+      </XStack>
+      {children}
+    </YStack>
+  );
+});

--- a/apps/mobile/components/builder/BuilderView.tsx
+++ b/apps/mobile/components/builder/BuilderView.tsx
@@ -91,7 +91,7 @@ export const BuilderView = memo(function BuilderView({
     async (schema: string | undefined, table: string) => {
       setLoadingColumns(true);
       try {
-        const cols = await instance.describeTable(schema ?? "public", table);
+        const cols = await instance.describeTable(schema, table);
         setColumns(cols);
       } catch (err) {
         setError(formatQueryError(err, type));

--- a/apps/mobile/components/builder/BuilderView.tsx
+++ b/apps/mobile/components/builder/BuilderView.tsx
@@ -1,0 +1,309 @@
+import { Ionicons } from "@expo/vector-icons";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Pressable, ScrollView } from "react-native";
+import { Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import { formatQueryError } from "../../lib/errors";
+import { useHaptic } from "../../lib/haptics";
+import type {
+  ColumnInfo,
+  DatabaseConnection,
+  DatabaseType,
+  TableInfo,
+} from "../../lib/types";
+import {
+  emptyMongoBuilderState,
+  emptySqlBuilderState,
+  isSqlType,
+  type MongoBuilderState,
+  mongoBuilderToString,
+  type SqlBuilderState,
+  sqlBuilderToString,
+} from "./builder-state";
+import { MongoBuilder } from "./MongoBuilder";
+import { PickerSheet } from "./PickerSheet";
+import { SqlBuilder } from "./SqlBuilder";
+
+type BuilderViewProps = {
+  connectionId: string;
+  type: DatabaseType;
+  instance: DatabaseConnection;
+  onQueryChange: (query: string) => void;
+};
+
+const buildTableKey = (schema: string | undefined, name: string): string =>
+  schema && schema !== "public" ? `${schema}.${name}` : name;
+
+export const BuilderView = memo(function BuilderView({
+  connectionId,
+  type,
+  instance,
+  onQueryChange,
+}: BuilderViewProps) {
+  const tamagui = useTamaguiTheme();
+  const haptic = useHaptic();
+
+  const [tables, setTables] = useState<TableInfo[]>([]);
+  const [columns, setColumns] = useState<ColumnInfo[]>([]);
+  const [loadingTables, setLoadingTables] = useState(false);
+  const [loadingColumns, setLoadingColumns] = useState(false);
+  const [showTablePicker, setShowTablePicker] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const sql = isSqlType(type);
+  const [sqlState, setSqlState] = useState<SqlBuilderState>(emptySqlBuilderState);
+  const [mongoState, setMongoState] = useState<MongoBuilderState>(emptyMongoBuilderState);
+
+  // Reset builder state when the connection changes.
+  const lastConnRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (lastConnRef.current !== connectionId) {
+      lastConnRef.current = connectionId;
+      setSqlState(emptySqlBuilderState());
+      setMongoState(emptyMongoBuilderState());
+      setTables([]);
+      setColumns([]);
+      setError(null);
+    }
+  }, [connectionId]);
+
+  const loadTables = useCallback(async () => {
+    setLoadingTables(true);
+    setError(null);
+    try {
+      const list = await instance.listTables();
+      setTables(list);
+    } catch (err) {
+      setError(formatQueryError(err, type));
+    } finally {
+      setLoadingTables(false);
+    }
+  }, [instance, type]);
+
+  // Initial load of tables when entering the builder.
+  useEffect(() => {
+    if (tables.length === 0 && !loadingTables) {
+      loadTables();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connectionId]);
+
+  const loadColumns = useCallback(
+    async (schema: string | undefined, table: string) => {
+      setLoadingColumns(true);
+      try {
+        const cols = await instance.describeTable(schema ?? "public", table);
+        setColumns(cols);
+      } catch (err) {
+        setError(formatQueryError(err, type));
+        setColumns([]);
+      } finally {
+        setLoadingColumns(false);
+      }
+    },
+    [instance, type],
+  );
+
+  // Auto-load columns whenever the table/collection changes.
+  useEffect(() => {
+    if (sql) {
+      const t = sqlState.table;
+      if (t) loadColumns(t.schema, t.name);
+      else setColumns([]);
+    } else {
+      const c = mongoState.collection;
+      if (c) loadColumns(undefined, c);
+      else setColumns([]);
+    }
+  }, [
+    sql,
+    sqlState.table?.schema,
+    sqlState.table?.name,
+    mongoState.collection,
+    loadColumns,
+  ]);
+
+  // Live-emit the generated query string.
+  const generatedQuery = useMemo(() => {
+    if (sql) return sqlBuilderToString(sqlState, type);
+    return mongoBuilderToString(mongoState);
+  }, [sql, sqlState, mongoState, type]);
+
+  useEffect(() => {
+    onQueryChange(generatedQuery);
+  }, [generatedQuery, onQueryChange]);
+
+  const handlePickTable = useCallback(
+    (id: string) => {
+      const picked = tables.find((t) => buildTableKey(t.schema, t.name) === id);
+      if (!picked) return;
+      haptic.light();
+      if (sql) {
+        setSqlState((prev) => ({
+          ...emptySqlBuilderState(),
+          limit: prev.limit,
+          table: { schema: picked.schema, name: picked.name },
+        }));
+      } else {
+        setMongoState((prev) => ({
+          ...emptyMongoBuilderState(),
+          limit: prev.limit,
+          collection: picked.name,
+        }));
+      }
+    },
+    [tables, sql, haptic],
+  );
+
+  const tableOptions = useMemo(
+    () =>
+      tables.map((t) => ({
+        id: buildTableKey(t.schema, t.name),
+        label: t.name,
+        sublabel: t.schema && t.schema !== "public" ? `${t.schema} · ${t.type}` : t.type,
+      })),
+    [tables],
+  );
+
+  const currentTableId = sql
+    ? sqlState.table
+      ? buildTableKey(sqlState.table.schema, sqlState.table.name)
+      : null
+    : (mongoState.collection ?? null);
+
+  return (
+    <YStack gap="$md" flex={1}>
+      <XStack alignItems="center" justifyContent="space-between">
+        <Text
+          color="$placeholderColor"
+          fontSize={11}
+          fontFamily="$mono"
+          letterSpacing={0.4}
+        >
+          {sql ? "SQL builder" : "MongoDB builder"}
+        </Text>
+        <Pressable hitSlop={6} onPress={loadTables} disabled={loadingTables}>
+          <XStack
+            alignItems="center"
+            gap={4}
+            paddingHorizontal={8}
+            paddingVertical={4}
+            borderRadius={999}
+            backgroundColor="$surfaceMuted"
+          >
+            <Ionicons
+              name="refresh"
+              size={11}
+              color={tamagui.placeholderColor.val}
+            />
+            <Text color="$placeholderColor" fontSize={11} fontWeight="600">
+              {loadingTables ? "Loading…" : "Refresh"}
+            </Text>
+          </XStack>
+        </Pressable>
+      </XStack>
+
+      {error ? (
+        <XStack
+          paddingHorizontal="$sm"
+          paddingVertical="$sm"
+          borderRadius="$sm"
+          backgroundColor="$dangerMuted"
+          borderWidth={1}
+          borderColor="$danger"
+        >
+          <Text color="$danger" fontSize={12} flex={1}>
+            {error}
+          </Text>
+        </XStack>
+      ) : null}
+
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 24 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <YStack gap="$md">
+          {sql ? (
+            <SqlBuilder
+              state={sqlState}
+              onChange={setSqlState}
+              type={type}
+              tables={tables}
+              columns={columns}
+              loadingTables={loadingTables}
+              onPickTable={() => setShowTablePicker(true)}
+            />
+          ) : (
+            <MongoBuilder
+              state={mongoState}
+              onChange={setMongoState}
+              collections={tables}
+              fields={columns}
+              loadingCollections={loadingTables}
+              onPickCollection={() => setShowTablePicker(true)}
+            />
+          )}
+
+          <YStack gap={6}>
+            <XStack alignItems="center" justifyContent="space-between">
+              <Text
+                color="$placeholderColor"
+                fontSize={11}
+                fontFamily="$mono"
+                textTransform="uppercase"
+                letterSpacing={0.5}
+                fontWeight="700"
+              >
+                Preview
+              </Text>
+              {loadingColumns ? (
+                <Text color="$placeholderColor" fontSize={10}>
+                  loading columns…
+                </Text>
+              ) : null}
+            </XStack>
+            <YStack
+              backgroundColor="$surface"
+              borderWidth={1}
+              borderColor="$borderColor"
+              borderRadius="$sm"
+              padding={10}
+              minHeight={64}
+            >
+              {generatedQuery ? (
+                <Text
+                  color="$color"
+                  fontSize={12}
+                  fontFamily="$mono"
+                  selectable
+                >
+                  {generatedQuery}
+                </Text>
+              ) : (
+                <Text color="$placeholderColor" fontSize={12}>
+                  {sql
+                    ? "Pick a table to start building."
+                    : "Pick a collection to start building."}
+                </Text>
+              )}
+            </YStack>
+          </YStack>
+        </YStack>
+      </ScrollView>
+
+      <PickerSheet
+        open={showTablePicker}
+        onOpenChange={setShowTablePicker}
+        title={sql ? "Pick a table" : "Pick a collection"}
+        options={tableOptions}
+        selected={currentTableId ? [currentTableId] : []}
+        emptyText={
+          loadingTables ? "Loading…" : "No tables found. Tap Refresh."
+        }
+        onSelect={(ids) => {
+          if (ids.length > 0) handlePickTable(ids[0]);
+        }}
+      />
+    </YStack>
+  );
+});

--- a/apps/mobile/components/builder/BuilderView.tsx
+++ b/apps/mobile/components/builder/BuilderView.tsx
@@ -4,12 +4,7 @@ import { Pressable, ScrollView } from "react-native";
 import { Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
 import { formatQueryError } from "../../lib/errors";
 import { useHaptic } from "../../lib/haptics";
-import type {
-  ColumnInfo,
-  DatabaseConnection,
-  DatabaseType,
-  TableInfo,
-} from "../../lib/types";
+import type { ColumnInfo, DatabaseConnection, DatabaseType, TableInfo } from "../../lib/types";
 import {
   emptyMongoBuilderState,
   emptySqlBuilderState,
@@ -138,13 +133,7 @@ export const BuilderView = memo(function BuilderView({
         setColumns([]);
       }
     }
-  }, [
-    sql,
-    sqlState.table?.schema,
-    sqlState.table?.name,
-    mongoState.collection,
-    loadColumns,
-  ]);
+  }, [sql, sqlState.table?.schema, sqlState.table?.name, mongoState.collection, loadColumns]);
 
   // Live-emit the generated query string.
   const generatedQuery = useMemo(() => {
@@ -197,12 +186,7 @@ export const BuilderView = memo(function BuilderView({
   return (
     <YStack gap="$md" flex={1}>
       <XStack alignItems="center" justifyContent="space-between">
-        <Text
-          color="$placeholderColor"
-          fontSize={11}
-          fontFamily="$mono"
-          letterSpacing={0.4}
-        >
+        <Text color="$placeholderColor" fontSize={11} fontFamily="$mono" letterSpacing={0.4}>
           {sql ? "SQL builder" : "MongoDB builder"}
         </Text>
         <Pressable hitSlop={6} onPress={loadTables} disabled={loadingTables}>
@@ -214,11 +198,7 @@ export const BuilderView = memo(function BuilderView({
             borderRadius={999}
             backgroundColor="$surfaceMuted"
           >
-            <Ionicons
-              name="refresh"
-              size={11}
-              color={tamagui.placeholderColor.val}
-            />
+            <Ionicons name="refresh" size={11} color={tamagui.placeholderColor.val} />
             <Text color="$placeholderColor" fontSize={11} fontWeight="600">
               {loadingTables ? "Loading…" : "Refresh"}
             </Text>
@@ -295,19 +275,12 @@ export const BuilderView = memo(function BuilderView({
               minHeight={64}
             >
               {generatedQuery ? (
-                <Text
-                  color="$color"
-                  fontSize={12}
-                  fontFamily="$mono"
-                  selectable
-                >
+                <Text color="$color" fontSize={12} fontFamily="$mono" selectable>
                   {generatedQuery}
                 </Text>
               ) : (
                 <Text color="$placeholderColor" fontSize={12}>
-                  {sql
-                    ? "Pick a table to start building."
-                    : "Pick a collection to start building."}
+                  {sql ? "Pick a table to start building." : "Pick a collection to start building."}
                 </Text>
               )}
             </YStack>
@@ -321,9 +294,7 @@ export const BuilderView = memo(function BuilderView({
         title={sql ? "Pick a table" : "Pick a collection"}
         options={tableOptions}
         selected={currentTableId ? [currentTableId] : []}
-        emptyText={
-          loadingTables ? "Loading…" : "No tables found. Tap Refresh."
-        }
+        emptyText={loadingTables ? "Loading…" : "No tables found. Tap Refresh."}
         onSelect={(ids) => {
           if (ids.length > 0) handlePickTable(ids[0]);
         }}

--- a/apps/mobile/components/builder/BuilderView.tsx
+++ b/apps/mobile/components/builder/BuilderView.tsx
@@ -53,11 +53,20 @@ export const BuilderView = memo(function BuilderView({
   const [sqlState, setSqlState] = useState<SqlBuilderState>(emptySqlBuilderState);
   const [mongoState, setMongoState] = useState<MongoBuilderState>(emptyMongoBuilderState);
 
+  // Request tokens guard async metadata calls. A connection switch or a fast
+  // table swap can leave earlier `listTables` / `describeTable` promises in
+  // flight; their resolutions must not overwrite state belonging to a newer
+  // request.
+  const tablesReqRef = useRef(0);
+  const columnsReqRef = useRef(0);
+
   // Reset builder state when the connection changes.
   const lastConnRef = useRef<string | null>(null);
   useEffect(() => {
     if (lastConnRef.current !== connectionId) {
       lastConnRef.current = connectionId;
+      tablesReqRef.current += 1;
+      columnsReqRef.current += 1;
       setSqlState(emptySqlBuilderState());
       setMongoState(emptyMongoBuilderState());
       setTables([]);
@@ -67,15 +76,18 @@ export const BuilderView = memo(function BuilderView({
   }, [connectionId]);
 
   const loadTables = useCallback(async () => {
+    const reqId = ++tablesReqRef.current;
     setLoadingTables(true);
     setError(null);
     try {
       const list = await instance.listTables();
+      if (tablesReqRef.current !== reqId) return;
       setTables(list);
     } catch (err) {
+      if (tablesReqRef.current !== reqId) return;
       setError(formatQueryError(err, type));
     } finally {
-      setLoadingTables(false);
+      if (tablesReqRef.current === reqId) setLoadingTables(false);
     }
   }, [instance, type]);
 
@@ -89,30 +101,42 @@ export const BuilderView = memo(function BuilderView({
 
   const loadColumns = useCallback(
     async (schema: string | undefined, table: string) => {
+      const reqId = ++columnsReqRef.current;
+      setColumns([]);
       setLoadingColumns(true);
       try {
         const cols = await instance.describeTable(schema, table);
+        if (columnsReqRef.current !== reqId) return;
         setColumns(cols);
       } catch (err) {
+        if (columnsReqRef.current !== reqId) return;
         setError(formatQueryError(err, type));
         setColumns([]);
       } finally {
-        setLoadingColumns(false);
+        if (columnsReqRef.current === reqId) setLoadingColumns(false);
       }
     },
     [instance, type],
   );
 
-  // Auto-load columns whenever the table/collection changes.
+  // Auto-load columns whenever the table/collection changes. Bumping
+  // `columnsReqRef` on clear cancels any in-flight describe call so a stale
+  // response can't repopulate the picker after the user deselects.
   useEffect(() => {
     if (sql) {
       const t = sqlState.table;
       if (t) loadColumns(t.schema, t.name);
-      else setColumns([]);
+      else {
+        columnsReqRef.current += 1;
+        setColumns([]);
+      }
     } else {
       const c = mongoState.collection;
       if (c) loadColumns(undefined, c);
-      else setColumns([]);
+      else {
+        columnsReqRef.current += 1;
+        setColumns([]);
+      }
     }
   }, [
     sql,

--- a/apps/mobile/components/builder/ConditionRow.tsx
+++ b/apps/mobile/components/builder/ConditionRow.tsx
@@ -1,0 +1,202 @@
+import { Ionicons } from "@expo/vector-icons";
+import { memo, useState } from "react";
+import { Pressable, TextInput } from "react-native";
+import { Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import { useHaptic } from "../../lib/haptics";
+import type { ColumnInfo } from "../../lib/types";
+import { PickerSheet } from "./PickerSheet";
+
+type ConditionRowProps = {
+  index: number;
+  combinator?: "AND" | "OR";
+  onCombinatorChange?: (next: "AND" | "OR") => void;
+  column: string;
+  onColumnChange: (column: string) => void;
+  columns: ColumnInfo[];
+  operator: string;
+  onOperatorChange: (op: string) => void;
+  operators: string[];
+  value: string;
+  onValueChange: (value: string) => void;
+  hideValue: boolean;
+  valuePlaceholder?: string;
+  onRemove: () => void;
+};
+
+export const ConditionRow = memo(function ConditionRow({
+  index,
+  combinator,
+  onCombinatorChange,
+  column,
+  onColumnChange,
+  columns,
+  operator,
+  onOperatorChange,
+  operators,
+  value,
+  onValueChange,
+  hideValue,
+  valuePlaceholder,
+  onRemove,
+}: ConditionRowProps) {
+  const tamagui = useTamaguiTheme();
+  const haptic = useHaptic();
+  const [showColumns, setShowColumns] = useState(false);
+  const [showOps, setShowOps] = useState(false);
+
+  return (
+    <YStack gap={6}>
+      {index > 0 && combinator ? (
+        <XStack gap={6}>
+          {(["AND", "OR"] as const).map((c) => {
+            const active = combinator === c;
+            return (
+              <Pressable
+                key={c}
+                onPress={() => {
+                  haptic.light();
+                  onCombinatorChange?.(c);
+                }}
+              >
+                <XStack
+                  paddingHorizontal={10}
+                  paddingVertical={4}
+                  borderRadius={999}
+                  backgroundColor={active ? "$primaryMuted" : "$surfaceMuted"}
+                >
+                  <Text
+                    color={active ? "$primary" : "$placeholderColor"}
+                    fontSize={11}
+                    fontWeight="600"
+                    fontFamily="$mono"
+                  >
+                    {c}
+                  </Text>
+                </XStack>
+              </Pressable>
+            );
+          })}
+        </XStack>
+      ) : null}
+
+      <XStack
+        gap={6}
+        alignItems="center"
+        backgroundColor="$surface"
+        borderWidth={1}
+        borderColor="$borderColor"
+        borderRadius="$sm"
+        padding={6}
+      >
+        <Pressable onPress={() => setShowColumns(true)} style={{ flex: 1 }}>
+          <XStack
+            paddingHorizontal={8}
+            paddingVertical={6}
+            borderRadius={6}
+            backgroundColor="$surfaceMuted"
+            alignItems="center"
+            gap={4}
+          >
+            <Text
+              color={column ? "$color" : "$placeholderColor"}
+              fontSize={12}
+              fontFamily="$mono"
+              numberOfLines={1}
+              flex={1}
+            >
+              {column || "column"}
+            </Text>
+            <Ionicons name="chevron-down" size={11} color={tamagui.placeholderColor.val} />
+          </XStack>
+        </Pressable>
+
+        <Pressable onPress={() => setShowOps(true)}>
+          <XStack
+            paddingHorizontal={8}
+            paddingVertical={6}
+            borderRadius={6}
+            backgroundColor="$primaryMuted"
+            alignItems="center"
+            gap={4}
+          >
+            <Text color="$primary" fontSize={12} fontWeight="600" fontFamily="$mono">
+              {operator}
+            </Text>
+            <Ionicons name="chevron-down" size={11} color={tamagui.primary.val} />
+          </XStack>
+        </Pressable>
+
+        {hideValue ? (
+          <YStack flex={1} />
+        ) : (
+          <XStack
+            flex={1}
+            paddingHorizontal={8}
+            paddingVertical={4}
+            borderRadius={6}
+            backgroundColor="$surfaceMuted"
+          >
+            <TextInput
+              value={value}
+              onChangeText={onValueChange}
+              placeholder={valuePlaceholder ?? "value"}
+              placeholderTextColor={tamagui.placeholderColor.val}
+              autoCapitalize="none"
+              autoCorrect={false}
+              style={{
+                flex: 1,
+                color: tamagui.color.val,
+                fontSize: 12,
+                fontFamily: "JetBrainsMono",
+                paddingVertical: 4,
+              }}
+            />
+          </XStack>
+        )}
+
+        <Pressable
+          onPress={() => {
+            haptic.light();
+            onRemove();
+          }}
+          hitSlop={6}
+        >
+          <YStack
+            width={26}
+            height={26}
+            borderRadius={13}
+            backgroundColor="$surfaceMuted"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Ionicons name="close" size={13} color={tamagui.placeholderColor.val} />
+          </YStack>
+        </Pressable>
+      </XStack>
+
+      <PickerSheet
+        open={showColumns}
+        onOpenChange={setShowColumns}
+        title="Pick a column"
+        options={columns.map((c) => ({ id: c.name, label: c.name, sublabel: c.type }))}
+        selected={column ? [column] : []}
+        onSelect={(ids) => {
+          if (ids.length > 0) onColumnChange(ids[0]);
+        }}
+        emptyText="No columns. Pick a table first."
+      />
+
+      <PickerSheet
+        open={showOps}
+        onOpenChange={setShowOps}
+        title="Pick an operator"
+        options={operators.map((o) => ({ id: o, label: o }))}
+        selected={[operator]}
+        searchable={false}
+        onSelect={(ids) => {
+          if (ids.length > 0) onOperatorChange(ids[0]);
+        }}
+      />
+    </YStack>
+  );
+});

--- a/apps/mobile/components/builder/MongoBuilder.tsx
+++ b/apps/mobile/components/builder/MongoBuilder.tsx
@@ -1,0 +1,321 @@
+import { Ionicons } from "@expo/vector-icons";
+import { memo, useCallback, useState } from "react";
+import { Pressable, TextInput } from "react-native";
+import { Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import { useHaptic } from "../../lib/haptics";
+import type { ColumnInfo, TableInfo } from "../../lib/types";
+import { BuilderSection } from "./BuilderSection";
+import {
+  type MongoBuilderState,
+  type MongoFilter,
+  type MongoOperator,
+  MONGO_OPERATORS,
+  type MongoSort,
+  newId,
+} from "./builder-state";
+import { ConditionRow } from "./ConditionRow";
+import { PickerSheet } from "./PickerSheet";
+import { SortRow } from "./SortRow";
+
+type MongoBuilderProps = {
+  state: MongoBuilderState;
+  onChange: (next: MongoBuilderState) => void;
+  collections: TableInfo[];
+  fields: ColumnInfo[];
+  loadingCollections: boolean;
+  onPickCollection: () => void;
+};
+
+const placeholderForOperator = (op: MongoOperator): string => {
+  switch (op) {
+    case "$in":
+    case "$nin":
+      return "a, b, c";
+    case "$exists":
+      return "true / false";
+    case "$regex":
+      return "^pattern";
+    default:
+      return "value";
+  }
+};
+
+export const MongoBuilder = memo(function MongoBuilder({
+  state,
+  onChange,
+  fields,
+  loadingCollections,
+  collections,
+  onPickCollection,
+}: MongoBuilderProps) {
+  const tamagui = useTamaguiTheme();
+  const haptic = useHaptic();
+  const [showProjection, setShowProjection] = useState(false);
+
+  const updateFilter = useCallback(
+    (id: string, patch: Partial<MongoFilter>) => {
+      onChange({
+        ...state,
+        filters: state.filters.map((f) => (f.id === id ? { ...f, ...patch } : f)),
+      });
+    },
+    [state, onChange],
+  );
+
+  const removeFilter = useCallback(
+    (id: string) => onChange({ ...state, filters: state.filters.filter((f) => f.id !== id) }),
+    [state, onChange],
+  );
+
+  const addFilter = useCallback(() => {
+    haptic.light();
+    const f: MongoFilter = {
+      id: newId(),
+      field: fields[0]?.name ?? "",
+      operator: "$eq",
+      value: "",
+    };
+    onChange({ ...state, filters: [...state.filters, f] });
+  }, [state, onChange, fields, haptic]);
+
+  const updateSort = useCallback(
+    (id: string, patch: Partial<MongoSort>) =>
+      onChange({
+        ...state,
+        sort: state.sort.map((s) => (s.id === id ? { ...s, ...patch } : s)),
+      }),
+    [state, onChange],
+  );
+
+  const removeSort = useCallback(
+    (id: string) => onChange({ ...state, sort: state.sort.filter((s) => s.id !== id) }),
+    [state, onChange],
+  );
+
+  const addSort = useCallback(() => {
+    haptic.light();
+    const s: MongoSort = { id: newId(), field: fields[0]?.name ?? "", dir: 1 };
+    onChange({ ...state, sort: [...state.sort, s] });
+  }, [state, onChange, fields, haptic]);
+
+  const updateLimit = useCallback(
+    (text: string) => {
+      const n = parseInt(text, 10);
+      onChange({ ...state, limit: Number.isFinite(n) && n > 0 ? n : null });
+    },
+    [state, onChange],
+  );
+
+  const collectionsEmpty = collections.length === 0 && !loadingCollections;
+
+  return (
+    <YStack gap="$md">
+      <BuilderSection title="Collection">
+        <Pressable onPress={onPickCollection}>
+          <XStack
+            alignItems="center"
+            backgroundColor="$surface"
+            borderWidth={1}
+            borderColor="$borderColor"
+            borderRadius="$sm"
+            paddingHorizontal="$sm"
+            paddingVertical="$sm"
+            gap="$sm"
+          >
+            <Ionicons name="folder-outline" size={14} color={tamagui.placeholderColor.val} />
+            <Text
+              color={state.collection ? "$color" : "$placeholderColor"}
+              fontSize={14}
+              fontFamily="$mono"
+              flex={1}
+              numberOfLines={1}
+            >
+              {collectionsEmpty
+                ? "Tap Refresh in the editor to load collections"
+                : (state.collection ?? "Pick a collection…")}
+            </Text>
+            <Ionicons name="chevron-forward" size={13} color={tamagui.placeholderColor.val} />
+          </XStack>
+        </Pressable>
+      </BuilderSection>
+
+      <BuilderSection
+        title="Projection"
+        hint={state.projection.length === 0 ? "all fields" : `${state.projection.length} kept`}
+        onAdd={() => setShowProjection(true)}
+        addLabel="Pick"
+      >
+        <Pressable onPress={() => setShowProjection(true)}>
+          <XStack
+            flexWrap="wrap"
+            gap={6}
+            backgroundColor="$surface"
+            borderWidth={1}
+            borderColor="$borderColor"
+            borderRadius="$sm"
+            paddingHorizontal="$sm"
+            paddingVertical="$sm"
+            minHeight={40}
+            alignItems="center"
+          >
+            {state.projection.length === 0 ? (
+              <XStack
+                paddingHorizontal={10}
+                paddingVertical={4}
+                borderRadius={999}
+                backgroundColor="$primaryMuted"
+              >
+                <Text color="$primary" fontSize={12} fontWeight="600" fontFamily="$mono">
+                  all fields
+                </Text>
+              </XStack>
+            ) : (
+              state.projection.map((f) => (
+                <XStack
+                  key={f}
+                  paddingHorizontal={10}
+                  paddingVertical={4}
+                  borderRadius={999}
+                  backgroundColor="$surfaceMuted"
+                  alignItems="center"
+                  gap={4}
+                >
+                  <Text color="$color" fontSize={12} fontFamily="$mono">
+                    {f}
+                  </Text>
+                  <Pressable
+                    hitSlop={6}
+                    onPress={(e) => {
+                      e.stopPropagation();
+                      onChange({ ...state, projection: state.projection.filter((n) => n !== f) });
+                    }}
+                  >
+                    <Ionicons name="close" size={12} color={tamagui.placeholderColor.val} />
+                  </Pressable>
+                </XStack>
+              ))
+            )}
+          </XStack>
+        </Pressable>
+      </BuilderSection>
+
+      <BuilderSection title="Filter" hint="conditions" onAdd={addFilter}>
+        {state.filters.length === 0 ? (
+          <XStack
+            paddingHorizontal="$sm"
+            paddingVertical="$sm"
+            borderRadius="$sm"
+            backgroundColor="$surfaceMuted"
+            borderWidth={1}
+            borderColor="$borderColor"
+            borderStyle="dashed"
+          >
+            <Text color="$placeholderColor" fontSize={12}>
+              No filters. Returns all documents.
+            </Text>
+          </XStack>
+        ) : (
+          <YStack gap={6}>
+            {state.filters.map((f, idx) => (
+              <ConditionRow
+                key={f.id}
+                index={idx}
+                column={f.field}
+                onColumnChange={(c) => updateFilter(f.id, { field: c })}
+                columns={fields}
+                operator={f.operator}
+                onOperatorChange={(o) => updateFilter(f.id, { operator: o as MongoOperator })}
+                operators={[...MONGO_OPERATORS]}
+                value={f.value}
+                onValueChange={(v) => updateFilter(f.id, { value: v })}
+                hideValue={false}
+                valuePlaceholder={placeholderForOperator(f.operator)}
+                onRemove={() => removeFilter(f.id)}
+              />
+            ))}
+          </YStack>
+        )}
+      </BuilderSection>
+
+      <BuilderSection title="Sort" onAdd={addSort}>
+        {state.sort.length === 0 ? (
+          <XStack
+            paddingHorizontal="$sm"
+            paddingVertical="$sm"
+            borderRadius="$sm"
+            backgroundColor="$surfaceMuted"
+            borderWidth={1}
+            borderColor="$borderColor"
+            borderStyle="dashed"
+          >
+            <Text color="$placeholderColor" fontSize={12}>
+              Server-default order.
+            </Text>
+          </XStack>
+        ) : (
+          <YStack gap={6}>
+            {state.sort.map((s) => (
+              <SortRow
+                key={s.id}
+                column={s.field}
+                onColumnChange={(c) => updateSort(s.id, { field: c })}
+                columns={fields}
+                dir={s.dir}
+                ascValue={1 as 1 | -1}
+                descValue={-1 as 1 | -1}
+                ascLabel="ASC"
+                descLabel="DESC"
+                onDirChange={(d) => updateSort(s.id, { dir: d })}
+                onRemove={() => removeSort(s.id)}
+              />
+            ))}
+          </YStack>
+        )}
+      </BuilderSection>
+
+      <BuilderSection title="Limit">
+        <XStack
+          alignItems="center"
+          backgroundColor="$surface"
+          borderWidth={1}
+          borderColor="$borderColor"
+          borderRadius="$sm"
+          paddingHorizontal="$sm"
+          paddingVertical={4}
+          gap="$sm"
+        >
+          <TextInput
+            value={state.limit ? String(state.limit) : ""}
+            onChangeText={updateLimit}
+            placeholder="No limit"
+            placeholderTextColor={tamagui.placeholderColor.val}
+            keyboardType="number-pad"
+            style={{
+              flex: 1,
+              color: tamagui.color.val,
+              fontSize: 14,
+              fontFamily: "JetBrainsMono",
+              paddingVertical: 6,
+            }}
+          />
+          {state.limit ? (
+            <Pressable hitSlop={6} onPress={() => onChange({ ...state, limit: null })}>
+              <Ionicons name="close-circle" size={14} color={tamagui.placeholderColor.val} />
+            </Pressable>
+          ) : null}
+        </XStack>
+      </BuilderSection>
+
+      <PickerSheet
+        open={showProjection}
+        onOpenChange={setShowProjection}
+        title="Project fields"
+        multi
+        options={fields.map((c) => ({ id: c.name, label: c.name, sublabel: c.type }))}
+        selected={state.projection}
+        emptyText="No fields known. Pick a collection and run a sample query first."
+        onSelect={(next) => onChange({ ...state, projection: next })}
+      />
+    </YStack>
+  );
+});

--- a/apps/mobile/components/builder/MongoBuilder.tsx
+++ b/apps/mobile/components/builder/MongoBuilder.tsx
@@ -6,10 +6,10 @@ import { useHaptic } from "../../lib/haptics";
 import type { ColumnInfo, TableInfo } from "../../lib/types";
 import { BuilderSection } from "./BuilderSection";
 import {
+  MONGO_OPERATORS,
   type MongoBuilderState,
   type MongoFilter,
   type MongoOperator,
-  MONGO_OPERATORS,
   type MongoSort,
   newId,
 } from "./builder-state";

--- a/apps/mobile/components/builder/MongoBuilder.tsx
+++ b/apps/mobile/components/builder/MongoBuilder.tsx
@@ -100,8 +100,14 @@ export const MongoBuilder = memo(function MongoBuilder({
 
   const updateLimit = useCallback(
     (text: string) => {
+      // Empty input clears the limit. `0` is meaningful in MongoDB (no
+      // server-side cap) so accept any non-negative integer.
+      if (text.trim() === "") {
+        onChange({ ...state, limit: null });
+        return;
+      }
       const n = parseInt(text, 10);
-      onChange({ ...state, limit: Number.isFinite(n) && n > 0 ? n : null });
+      onChange({ ...state, limit: Number.isFinite(n) && n >= 0 ? n : null });
     },
     [state, onChange],
   );

--- a/apps/mobile/components/builder/PickerSheet.tsx
+++ b/apps/mobile/components/builder/PickerSheet.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
-import { memo, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { Pressable, ScrollView, TextInput } from "react-native";
 import { Sheet, Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
 import { useHaptic } from "../../lib/haptics";
@@ -36,6 +36,13 @@ export const PickerSheet = memo(function PickerSheet({
   const tamagui = useTamaguiTheme();
   const haptic = useHaptic();
   const [search, setSearch] = useState("");
+
+  // Reset the search needle whenever the sheet is dismissed so the next time
+  // it opens (potentially for a different field) the user sees the full list,
+  // not the previously typed filter still applied.
+  useEffect(() => {
+    if (!open) setSearch("");
+  }, [open]);
 
   const filtered = useMemo(() => {
     if (!search.trim()) return options;

--- a/apps/mobile/components/builder/PickerSheet.tsx
+++ b/apps/mobile/components/builder/PickerSheet.tsx
@@ -1,0 +1,189 @@
+import { Ionicons } from "@expo/vector-icons";
+import { memo, useMemo, useState } from "react";
+import { Pressable, ScrollView, TextInput } from "react-native";
+import { Sheet, Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import { useHaptic } from "../../lib/haptics";
+
+export interface PickerOption {
+  id: string;
+  label: string;
+  sublabel?: string;
+}
+
+type PickerSheetProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  options: PickerOption[];
+  selected: string[];
+  multi?: boolean;
+  searchable?: boolean;
+  emptyText?: string;
+  onSelect: (ids: string[]) => void;
+};
+
+export const PickerSheet = memo(function PickerSheet({
+  open,
+  onOpenChange,
+  title,
+  options,
+  selected,
+  multi = false,
+  searchable = true,
+  emptyText = "Nothing to pick.",
+  onSelect,
+}: PickerSheetProps) {
+  const tamagui = useTamaguiTheme();
+  const haptic = useHaptic();
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return options;
+    const needle = search.trim().toLowerCase();
+    return options.filter(
+      (o) =>
+        o.label.toLowerCase().includes(needle) ||
+        (o.sublabel ?? "").toLowerCase().includes(needle),
+    );
+  }, [options, search]);
+
+  const toggle = (id: string) => {
+    haptic.light();
+    if (multi) {
+      if (selected.includes(id)) {
+        onSelect(selected.filter((s) => s !== id));
+      } else {
+        onSelect([...selected, id]);
+      }
+      return;
+    }
+    onSelect([id]);
+    onOpenChange(false);
+  };
+
+  return (
+    <Sheet
+      modal
+      open={open}
+      onOpenChange={onOpenChange}
+      animation="medium"
+      zIndex={200000}
+      dismissOnSnapToBottom
+      snapPoints={[80]}
+    >
+      <Sheet.Overlay
+        animation="lazy"
+        enterStyle={{ opacity: 0 }}
+        exitStyle={{ opacity: 0 }}
+        backgroundColor="$dialogOverlay"
+      />
+      <Sheet.Frame
+        backgroundColor="$surfaceElevated"
+        borderTopLeftRadius={20}
+        borderTopRightRadius={20}
+        padding="$lg"
+        gap="$md"
+      >
+        <Sheet.Handle backgroundColor="$dialogHandle" alignSelf="center" />
+        <XStack alignItems="center" justifyContent="space-between">
+          <Text fontSize={17} fontWeight="600" color="$color" letterSpacing={-0.2}>
+            {title}
+          </Text>
+          {multi ? (
+            <Pressable hitSlop={8} onPress={() => onOpenChange(false)}>
+              <Text color="$primary" fontSize={13} fontWeight="600">
+                Done
+              </Text>
+            </Pressable>
+          ) : null}
+        </XStack>
+
+        {searchable && options.length > 6 ? (
+          <XStack
+            alignItems="center"
+            backgroundColor="$surface"
+            borderRadius="$sm"
+            borderWidth={1}
+            borderColor="$borderColor"
+            paddingHorizontal="$sm"
+            gap={6}
+            height={36}
+          >
+            <Ionicons name="search" size={13} color={tamagui.placeholderColor.val} />
+            <TextInput
+              value={search}
+              onChangeText={setSearch}
+              placeholder="Search…"
+              placeholderTextColor={tamagui.placeholderColor.val}
+              autoCapitalize="none"
+              autoCorrect={false}
+              style={{ flex: 1, color: tamagui.color.val, fontSize: 14, paddingVertical: 0 }}
+            />
+            {search ? (
+              <Pressable hitSlop={6} onPress={() => setSearch("")}>
+                <Ionicons name="close-circle" size={14} color={tamagui.placeholderColor.val} />
+              </Pressable>
+            ) : null}
+          </XStack>
+        ) : null}
+
+        <ScrollView showsVerticalScrollIndicator={false}>
+          <YStack gap={6} paddingBottom={32}>
+            {filtered.length === 0 ? (
+              <Text color="$placeholderColor" fontSize={13} textAlign="center" paddingVertical="$lg">
+                {emptyText}
+              </Text>
+            ) : (
+              filtered.map((opt) => {
+                const isSelected = selected.includes(opt.id);
+                return (
+                  <Pressable key={opt.id} onPress={() => toggle(opt.id)}>
+                    <XStack
+                      alignItems="center"
+                      paddingHorizontal="$sm"
+                      paddingVertical="$sm"
+                      backgroundColor="$surface"
+                      borderRadius="$sm"
+                      borderWidth={1}
+                      borderColor={isSelected ? "$primary" : "$borderColor"}
+                      gap="$sm"
+                    >
+                      <YStack flex={1} gap={2}>
+                        <Text color="$color" fontSize={14} fontWeight="500" numberOfLines={1}>
+                          {opt.label}
+                        </Text>
+                        {opt.sublabel ? (
+                          <Text
+                            color="$placeholderColor"
+                            fontSize={11}
+                            fontFamily="$mono"
+                            numberOfLines={1}
+                          >
+                            {opt.sublabel}
+                          </Text>
+                        ) : null}
+                      </YStack>
+                      <Ionicons
+                        name={
+                          isSelected
+                            ? multi
+                              ? "checkbox"
+                              : "checkmark-circle"
+                            : multi
+                              ? "square-outline"
+                              : "ellipse-outline"
+                        }
+                        size={20}
+                        color={isSelected ? tamagui.primary.val : tamagui.placeholderColor.val}
+                      />
+                    </XStack>
+                  </Pressable>
+                );
+              })
+            )}
+          </YStack>
+        </ScrollView>
+      </Sheet.Frame>
+    </Sheet>
+  );
+});

--- a/apps/mobile/components/builder/PickerSheet.tsx
+++ b/apps/mobile/components/builder/PickerSheet.tsx
@@ -49,8 +49,7 @@ export const PickerSheet = memo(function PickerSheet({
     const needle = search.trim().toLowerCase();
     return options.filter(
       (o) =>
-        o.label.toLowerCase().includes(needle) ||
-        (o.sublabel ?? "").toLowerCase().includes(needle),
+        o.label.toLowerCase().includes(needle) || (o.sublabel ?? "").toLowerCase().includes(needle),
     );
   }, [options, search]);
 
@@ -137,7 +136,12 @@ export const PickerSheet = memo(function PickerSheet({
         <ScrollView showsVerticalScrollIndicator={false}>
           <YStack gap={6} paddingBottom={32}>
             {filtered.length === 0 ? (
-              <Text color="$placeholderColor" fontSize={13} textAlign="center" paddingVertical="$lg">
+              <Text
+                color="$placeholderColor"
+                fontSize={13}
+                textAlign="center"
+                paddingVertical="$lg"
+              >
                 {emptyText}
               </Text>
             ) : (

--- a/apps/mobile/components/builder/SortRow.tsx
+++ b/apps/mobile/components/builder/SortRow.tsx
@@ -1,0 +1,162 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useState } from "react";
+import { Pressable } from "react-native";
+import { Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import { useHaptic } from "../../lib/haptics";
+import type { ColumnInfo } from "../../lib/types";
+import { PickerSheet } from "./PickerSheet";
+
+type SortRowProps<Dir extends string | number> = {
+  column: string;
+  onColumnChange: (column: string) => void;
+  columns: ColumnInfo[];
+  dir: Dir;
+  ascValue: Dir;
+  descValue: Dir;
+  ascLabel: string;
+  descLabel: string;
+  onDirChange: (dir: Dir) => void;
+  onRemove: () => void;
+};
+
+export function SortRow<Dir extends string | number>({
+  column,
+  onColumnChange,
+  columns,
+  dir,
+  ascValue,
+  descValue,
+  ascLabel,
+  descLabel,
+  onDirChange,
+  onRemove,
+}: SortRowProps<Dir>) {
+  const tamagui = useTamaguiTheme();
+  const haptic = useHaptic();
+  const [showColumns, setShowColumns] = useState(false);
+
+  return (
+    <XStack
+      gap={6}
+      alignItems="center"
+      backgroundColor="$surface"
+      borderWidth={1}
+      borderColor="$borderColor"
+      borderRadius="$sm"
+      padding={6}
+    >
+      <Pressable onPress={() => setShowColumns(true)} style={{ flex: 1 }}>
+        <XStack
+          paddingHorizontal={8}
+          paddingVertical={6}
+          borderRadius={6}
+          backgroundColor="$surfaceMuted"
+          alignItems="center"
+          gap={4}
+        >
+          <Text
+            color={column ? "$color" : "$placeholderColor"}
+            fontSize={12}
+            fontFamily="$mono"
+            numberOfLines={1}
+            flex={1}
+          >
+            {column || "column"}
+          </Text>
+          <Ionicons name="chevron-down" size={11} color={tamagui.placeholderColor.val} />
+        </XStack>
+      </Pressable>
+
+      <XStack gap={4}>
+        <Pressable
+          onPress={() => {
+            haptic.light();
+            onDirChange(ascValue);
+          }}
+        >
+          <XStack
+            paddingHorizontal={10}
+            paddingVertical={6}
+            borderRadius={6}
+            backgroundColor={dir === ascValue ? "$primaryMuted" : "$surfaceMuted"}
+            alignItems="center"
+            gap={4}
+          >
+            <Ionicons
+              name="arrow-up"
+              size={11}
+              color={dir === ascValue ? tamagui.primary.val : tamagui.placeholderColor.val}
+            />
+            <Text
+              color={dir === ascValue ? "$primary" : "$placeholderColor"}
+              fontSize={11}
+              fontWeight="600"
+            >
+              {ascLabel}
+            </Text>
+          </XStack>
+        </Pressable>
+        <Pressable
+          onPress={() => {
+            haptic.light();
+            onDirChange(descValue);
+          }}
+        >
+          <XStack
+            paddingHorizontal={10}
+            paddingVertical={6}
+            borderRadius={6}
+            backgroundColor={dir === descValue ? "$primaryMuted" : "$surfaceMuted"}
+            alignItems="center"
+            gap={4}
+          >
+            <Ionicons
+              name="arrow-down"
+              size={11}
+              color={dir === descValue ? tamagui.primary.val : tamagui.placeholderColor.val}
+            />
+            <Text
+              color={dir === descValue ? "$primary" : "$placeholderColor"}
+              fontSize={11}
+              fontWeight="600"
+            >
+              {descLabel}
+            </Text>
+          </XStack>
+        </Pressable>
+      </XStack>
+
+      <Pressable
+        onPress={() => {
+          haptic.light();
+          onRemove();
+        }}
+        hitSlop={6}
+      >
+        <YStack
+          width={26}
+          height={26}
+          borderRadius={13}
+          backgroundColor="$surfaceMuted"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Ionicons name="close" size={13} color={tamagui.placeholderColor.val} />
+        </YStack>
+      </Pressable>
+
+      <PickerSheet
+        open={showColumns}
+        onOpenChange={setShowColumns}
+        title="Pick a column"
+        options={columns.map((c) => ({ id: c.name, label: c.name, sublabel: c.type }))}
+        selected={column ? [column] : []}
+        onSelect={(ids) => {
+          if (ids.length > 0) onColumnChange(ids[0]);
+        }}
+        emptyText="No columns. Pick a table first."
+      />
+    </XStack>
+  );
+}
+

--- a/apps/mobile/components/builder/SortRow.tsx
+++ b/apps/mobile/components/builder/SortRow.tsx
@@ -159,4 +159,3 @@ export function SortRow<Dir extends string | number>({
     </XStack>
   );
 }
-

--- a/apps/mobile/components/builder/SqlBuilder.tsx
+++ b/apps/mobile/components/builder/SqlBuilder.tsx
@@ -7,10 +7,10 @@ import type { ColumnInfo, DatabaseType, TableInfo } from "../../lib/types";
 import { BuilderSection } from "./BuilderSection";
 import {
   newId,
+  SQL_OPERATORS,
   type SqlBuilderState,
   type SqlCombinator,
   type SqlCondition,
-  SQL_OPERATORS,
   type SqlOperator,
   type SqlSort,
 } from "./builder-state";
@@ -35,8 +35,7 @@ const tableLabel = (state: SqlBuilderState): string => {
     : state.table.name;
 };
 
-const isOperatorWithoutValue = (op: SqlOperator) =>
-  op === "IS NULL" || op === "IS NOT NULL";
+const isOperatorWithoutValue = (op: SqlOperator) => op === "IS NULL" || op === "IS NOT NULL";
 
 const placeholderForOperator = (op: SqlOperator): string => {
   switch (op) {
@@ -254,7 +253,9 @@ export const SqlBuilder = memo(function SqlBuilder({
                   key={cond.id}
                   index={idx}
                   combinator={cond.combinator}
-                  onCombinatorChange={(c) => updateCondition(cond.id, { combinator: c as SqlCombinator })}
+                  onCombinatorChange={(c) =>
+                    updateCondition(cond.id, { combinator: c as SqlCombinator })
+                  }
                   column={cond.column}
                   onColumnChange={(c) => updateCondition(cond.id, { column: c })}
                   columns={columns}

--- a/apps/mobile/components/builder/SqlBuilder.tsx
+++ b/apps/mobile/components/builder/SqlBuilder.tsx
@@ -121,8 +121,15 @@ export const SqlBuilder = memo(function SqlBuilder({
 
   const updateLimit = useCallback(
     (text: string) => {
+      // Empty input clears the LIMIT clause (no cap). Any non-negative integer
+      // — including `0`, which is valid SQL meaning "return no rows" — is
+      // kept verbatim. Negative values fall back to null.
+      if (text.trim() === "") {
+        onChange({ ...state, limit: null });
+        return;
+      }
       const n = parseInt(text, 10);
-      onChange({ ...state, limit: Number.isFinite(n) && n > 0 ? n : null });
+      onChange({ ...state, limit: Number.isFinite(n) && n >= 0 ? n : null });
     },
     [state, onChange],
   );

--- a/apps/mobile/components/builder/SqlBuilder.tsx
+++ b/apps/mobile/components/builder/SqlBuilder.tsx
@@ -1,0 +1,350 @@
+import { Ionicons } from "@expo/vector-icons";
+import { memo, useCallback, useState } from "react";
+import { Pressable, TextInput } from "react-native";
+import { Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import { useHaptic } from "../../lib/haptics";
+import type { ColumnInfo, DatabaseType, TableInfo } from "../../lib/types";
+import { BuilderSection } from "./BuilderSection";
+import {
+  newId,
+  type SqlBuilderState,
+  type SqlCombinator,
+  type SqlCondition,
+  SQL_OPERATORS,
+  type SqlOperator,
+  type SqlSort,
+} from "./builder-state";
+import { ConditionRow } from "./ConditionRow";
+import { PickerSheet } from "./PickerSheet";
+import { SortRow } from "./SortRow";
+
+type SqlBuilderProps = {
+  state: SqlBuilderState;
+  onChange: (next: SqlBuilderState) => void;
+  type: DatabaseType;
+  tables: TableInfo[];
+  columns: ColumnInfo[]; // for the currently picked table
+  loadingTables: boolean;
+  onPickTable: () => void;
+};
+
+const tableLabel = (state: SqlBuilderState): string => {
+  if (!state.table) return "Pick a table…";
+  return state.table.schema && state.table.schema !== "public"
+    ? `${state.table.schema}.${state.table.name}`
+    : state.table.name;
+};
+
+const isOperatorWithoutValue = (op: SqlOperator) =>
+  op === "IS NULL" || op === "IS NOT NULL";
+
+const placeholderForOperator = (op: SqlOperator): string => {
+  switch (op) {
+    case "IN":
+    case "NOT IN":
+      return "a, b, c";
+    case "BETWEEN":
+      return "low, high";
+    case "LIKE":
+    case "NOT LIKE":
+      return "%pattern%";
+    default:
+      return "value";
+  }
+};
+
+export const SqlBuilder = memo(function SqlBuilder({
+  state,
+  onChange,
+  tables,
+  columns,
+  loadingTables,
+  onPickTable,
+}: SqlBuilderProps) {
+  const tamagui = useTamaguiTheme();
+  const haptic = useHaptic();
+  const [showColumns, setShowColumns] = useState(false);
+
+  const updateCondition = useCallback(
+    (id: string, patch: Partial<SqlCondition>) => {
+      onChange({
+        ...state,
+        conditions: state.conditions.map((c) => (c.id === id ? { ...c, ...patch } : c)),
+      });
+    },
+    [state, onChange],
+  );
+
+  const removeCondition = useCallback(
+    (id: string) => {
+      onChange({ ...state, conditions: state.conditions.filter((c) => c.id !== id) });
+    },
+    [state, onChange],
+  );
+
+  const addCondition = useCallback(() => {
+    haptic.light();
+    const fallback = columns[0]?.name ?? "";
+    const cond: SqlCondition = {
+      id: newId(),
+      combinator: "AND",
+      column: fallback,
+      operator: "=",
+      value: "",
+    };
+    onChange({ ...state, conditions: [...state.conditions, cond] });
+  }, [state, onChange, columns, haptic]);
+
+  const updateSort = useCallback(
+    (id: string, patch: Partial<SqlSort>) => {
+      onChange({
+        ...state,
+        sort: state.sort.map((s) => (s.id === id ? { ...s, ...patch } : s)),
+      });
+    },
+    [state, onChange],
+  );
+
+  const removeSort = useCallback(
+    (id: string) => {
+      onChange({ ...state, sort: state.sort.filter((s) => s.id !== id) });
+    },
+    [state, onChange],
+  );
+
+  const addSort = useCallback(() => {
+    haptic.light();
+    const fallback = columns[0]?.name ?? "";
+    const s: SqlSort = { id: newId(), column: fallback, dir: "ASC" };
+    onChange({ ...state, sort: [...state.sort, s] });
+  }, [state, onChange, columns, haptic]);
+
+  const updateLimit = useCallback(
+    (text: string) => {
+      const n = parseInt(text, 10);
+      onChange({ ...state, limit: Number.isFinite(n) && n > 0 ? n : null });
+    },
+    [state, onChange],
+  );
+
+  const setColumns = useCallback(
+    (next: string[]) => onChange({ ...state, columns: next }),
+    [state, onChange],
+  );
+
+  const tablesEmpty = tables.length === 0 && !loadingTables;
+
+  return (
+    <YStack gap="$md">
+      <BuilderSection title="From">
+        <Pressable onPress={onPickTable}>
+          <XStack
+            alignItems="center"
+            backgroundColor="$surface"
+            borderWidth={1}
+            borderColor="$borderColor"
+            borderRadius="$sm"
+            paddingHorizontal="$sm"
+            paddingVertical="$sm"
+            gap="$sm"
+          >
+            <Ionicons name="server-outline" size={14} color={tamagui.placeholderColor.val} />
+            <Text
+              color={state.table ? "$color" : "$placeholderColor"}
+              fontSize={14}
+              fontFamily="$mono"
+              flex={1}
+              numberOfLines={1}
+            >
+              {tablesEmpty ? "Tap Refresh in the editor to load tables" : tableLabel(state)}
+            </Text>
+            <Ionicons name="chevron-forward" size={13} color={tamagui.placeholderColor.val} />
+          </XStack>
+        </Pressable>
+      </BuilderSection>
+
+      <BuilderSection
+        title="Select"
+        hint={state.columns.length === 0 ? "all columns" : `${state.columns.length} picked`}
+        onAdd={() => setShowColumns(true)}
+        addLabel="Pick"
+      >
+        <Pressable onPress={() => setShowColumns(true)}>
+          <XStack
+            flexWrap="wrap"
+            gap={6}
+            backgroundColor="$surface"
+            borderWidth={1}
+            borderColor="$borderColor"
+            borderRadius="$sm"
+            paddingHorizontal="$sm"
+            paddingVertical="$sm"
+            minHeight={40}
+            alignItems="center"
+          >
+            {state.columns.length === 0 ? (
+              <XStack
+                paddingHorizontal={10}
+                paddingVertical={4}
+                borderRadius={999}
+                backgroundColor="$primaryMuted"
+              >
+                <Text color="$primary" fontSize={12} fontWeight="600" fontFamily="$mono">
+                  *
+                </Text>
+              </XStack>
+            ) : (
+              state.columns.map((c) => (
+                <XStack
+                  key={c}
+                  paddingHorizontal={10}
+                  paddingVertical={4}
+                  borderRadius={999}
+                  backgroundColor="$surfaceMuted"
+                  alignItems="center"
+                  gap={4}
+                >
+                  <Text color="$color" fontSize={12} fontFamily="$mono">
+                    {c}
+                  </Text>
+                  <Pressable
+                    hitSlop={6}
+                    onPress={(e) => {
+                      e.stopPropagation();
+                      setColumns(state.columns.filter((n) => n !== c));
+                    }}
+                  >
+                    <Ionicons name="close" size={12} color={tamagui.placeholderColor.val} />
+                  </Pressable>
+                </XStack>
+              ))
+            )}
+          </XStack>
+        </Pressable>
+      </BuilderSection>
+
+      <BuilderSection title="Where" hint="conditions" onAdd={addCondition}>
+        {state.conditions.length === 0 ? (
+          <XStack
+            paddingHorizontal="$sm"
+            paddingVertical="$sm"
+            borderRadius="$sm"
+            backgroundColor="$surfaceMuted"
+            borderWidth={1}
+            borderColor="$borderColor"
+            borderStyle="dashed"
+          >
+            <Text color="$placeholderColor" fontSize={12}>
+              No filters. Returns all rows.
+            </Text>
+          </XStack>
+        ) : (
+          <YStack gap={6}>
+            {state.conditions.map((cond, idx) => {
+              const op = cond.operator as SqlOperator;
+              return (
+                <ConditionRow
+                  key={cond.id}
+                  index={idx}
+                  combinator={cond.combinator}
+                  onCombinatorChange={(c) => updateCondition(cond.id, { combinator: c as SqlCombinator })}
+                  column={cond.column}
+                  onColumnChange={(c) => updateCondition(cond.id, { column: c })}
+                  columns={columns}
+                  operator={cond.operator}
+                  onOperatorChange={(o) => updateCondition(cond.id, { operator: o as SqlOperator })}
+                  operators={[...SQL_OPERATORS]}
+                  value={cond.value}
+                  onValueChange={(v) => updateCondition(cond.id, { value: v })}
+                  hideValue={isOperatorWithoutValue(op)}
+                  valuePlaceholder={placeholderForOperator(op)}
+                  onRemove={() => removeCondition(cond.id)}
+                />
+              );
+            })}
+          </YStack>
+        )}
+      </BuilderSection>
+
+      <BuilderSection title="Order by" onAdd={addSort}>
+        {state.sort.length === 0 ? (
+          <XStack
+            paddingHorizontal="$sm"
+            paddingVertical="$sm"
+            borderRadius="$sm"
+            backgroundColor="$surfaceMuted"
+            borderWidth={1}
+            borderColor="$borderColor"
+            borderStyle="dashed"
+          >
+            <Text color="$placeholderColor" fontSize={12}>
+              Unordered.
+            </Text>
+          </XStack>
+        ) : (
+          <YStack gap={6}>
+            {state.sort.map((s) => (
+              <SortRow
+                key={s.id}
+                column={s.column}
+                onColumnChange={(c) => updateSort(s.id, { column: c })}
+                columns={columns}
+                dir={s.dir}
+                ascValue="ASC"
+                descValue="DESC"
+                ascLabel="ASC"
+                descLabel="DESC"
+                onDirChange={(d) => updateSort(s.id, { dir: d })}
+                onRemove={() => removeSort(s.id)}
+              />
+            ))}
+          </YStack>
+        )}
+      </BuilderSection>
+
+      <BuilderSection title="Limit">
+        <XStack
+          alignItems="center"
+          backgroundColor="$surface"
+          borderWidth={1}
+          borderColor="$borderColor"
+          borderRadius="$sm"
+          paddingHorizontal="$sm"
+          paddingVertical={4}
+          gap="$sm"
+        >
+          <TextInput
+            value={state.limit ? String(state.limit) : ""}
+            onChangeText={updateLimit}
+            placeholder="No limit"
+            placeholderTextColor={tamagui.placeholderColor.val}
+            keyboardType="number-pad"
+            style={{
+              flex: 1,
+              color: tamagui.color.val,
+              fontSize: 14,
+              fontFamily: "JetBrainsMono",
+              paddingVertical: 6,
+            }}
+          />
+          {state.limit ? (
+            <Pressable hitSlop={6} onPress={() => onChange({ ...state, limit: null })}>
+              <Ionicons name="close-circle" size={14} color={tamagui.placeholderColor.val} />
+            </Pressable>
+          ) : null}
+        </XStack>
+      </BuilderSection>
+
+      <PickerSheet
+        open={showColumns}
+        onOpenChange={setShowColumns}
+        title="Pick columns"
+        multi
+        options={columns.map((c) => ({ id: c.name, label: c.name, sublabel: c.type }))}
+        selected={state.columns}
+        emptyText="No columns. Pick a table first."
+        onSelect={setColumns}
+      />
+    </YStack>
+  );
+});

--- a/apps/mobile/components/builder/builder-state.ts
+++ b/apps/mobile/components/builder/builder-state.ts
@@ -82,6 +82,13 @@ const renderSqlCondition = (cond: SqlCondition, type: DatabaseType): string | nu
     return `${col} ${cond.operator}`;
   }
 
+  // Live-sync: skip the clause until the user has actually typed a value.
+  // Mirrors the same intent on the Mongo path so blank operands don't
+  // silently shrink the result set with `= ''` / `LIKE ''`.
+  if (cond.value.trim() === "") {
+    return null;
+  }
+
   if (cond.operator === "IN" || cond.operator === "NOT IN") {
     const items = splitListLiteral(cond.value);
     if (items.length === 0) return null;
@@ -220,7 +227,11 @@ const coerceLiteral = (raw: string): unknown => {
 const buildMongoFilterClause = (filter: MongoFilter): unknown | null => {
   const trimmed = filter.value.trim();
   if (filter.operator === "$exists") {
-    return { $exists: trimmed.toLowerCase() !== "false" };
+    // Don't default an unset $exists to true — adding the operator should
+    // not change results until the user types `true` or `false` explicitly.
+    const lower = trimmed.toLowerCase();
+    if (lower !== "true" && lower !== "false") return null;
+    return { $exists: lower === "true" };
   }
   if (filter.operator === "$regex") {
     if (trimmed === "") return null;

--- a/apps/mobile/components/builder/builder-state.ts
+++ b/apps/mobile/components/builder/builder-state.ts
@@ -1,0 +1,280 @@
+import type { DatabaseType } from "../../lib/types";
+import {
+  formatSqlLiteral,
+  inferLiteralKind,
+  quoteIdent,
+  quoteQualified,
+  splitListLiteral,
+} from "./identifiers";
+
+// ── SQL ─────────────────────────────────────────────────────────────────────
+
+export type SqlOperator =
+  | "="
+  | "!="
+  | ">"
+  | "<"
+  | ">="
+  | "<="
+  | "LIKE"
+  | "NOT LIKE"
+  | "IN"
+  | "NOT IN"
+  | "BETWEEN"
+  | "IS NULL"
+  | "IS NOT NULL";
+
+export type SqlCombinator = "AND" | "OR";
+
+export interface SqlCondition {
+  id: string;
+  combinator: SqlCombinator;
+  column: string;
+  operator: SqlOperator;
+  value: string;
+}
+
+export interface SqlSort {
+  id: string;
+  column: string;
+  dir: "ASC" | "DESC";
+}
+
+export interface SqlBuilderState {
+  table: { schema?: string; name: string } | null;
+  columns: string[]; // empty → SELECT *
+  conditions: SqlCondition[];
+  sort: SqlSort[];
+  limit: number | null;
+}
+
+export const emptySqlBuilderState = (): SqlBuilderState => ({
+  table: null,
+  columns: [],
+  conditions: [],
+  sort: [],
+  limit: 100,
+});
+
+const SQL_OPERATORS_NO_VALUE: ReadonlySet<SqlOperator> = new Set(["IS NULL", "IS NOT NULL"]);
+
+export const SQL_OPERATORS: SqlOperator[] = [
+  "=",
+  "!=",
+  ">",
+  "<",
+  ">=",
+  "<=",
+  "LIKE",
+  "NOT LIKE",
+  "IN",
+  "NOT IN",
+  "BETWEEN",
+  "IS NULL",
+  "IS NOT NULL",
+];
+
+const renderSqlCondition = (cond: SqlCondition, type: DatabaseType): string | null => {
+  if (!cond.column) return null;
+  const col = quoteIdent(cond.column, type);
+
+  if (SQL_OPERATORS_NO_VALUE.has(cond.operator)) {
+    return `${col} ${cond.operator}`;
+  }
+
+  if (cond.operator === "IN" || cond.operator === "NOT IN") {
+    const items = splitListLiteral(cond.value);
+    if (items.length === 0) return null;
+    const list = items.map((v) => formatSqlLiteral(v, type)).join(", ");
+    return `${col} ${cond.operator} (${list})`;
+  }
+
+  if (cond.operator === "BETWEEN") {
+    const items = splitListLiteral(cond.value);
+    if (items.length !== 2) return null;
+    return `${col} BETWEEN ${formatSqlLiteral(items[0], type)} AND ${formatSqlLiteral(items[1], type)}`;
+  }
+
+  if (cond.operator === "LIKE" || cond.operator === "NOT LIKE") {
+    return `${col} ${cond.operator} ${formatSqlLiteral(cond.value, type)}`;
+  }
+
+  return `${col} ${cond.operator} ${formatSqlLiteral(cond.value, type)}`;
+};
+
+export const sqlBuilderToString = (
+  state: SqlBuilderState,
+  type: DatabaseType,
+): string => {
+  if (!state.table) return "";
+
+  const cols =
+    state.columns.length === 0
+      ? "*"
+      : state.columns.map((c) => quoteIdent(c, type)).join(", ");
+  const tableRef = quoteQualified(state.table.name, type, state.table.schema);
+
+  let sql = `SELECT ${cols}\nFROM ${tableRef}`;
+
+  if (state.conditions.length > 0) {
+    const parts: string[] = [];
+    state.conditions.forEach((cond, idx) => {
+      const rendered = renderSqlCondition(cond, type);
+      if (!rendered) return;
+      if (parts.length === 0) {
+        parts.push(rendered);
+      } else {
+        parts.push(`${cond.combinator} ${rendered}`);
+      }
+      void idx;
+    });
+    if (parts.length > 0) {
+      sql += `\nWHERE ${parts.join("\n  ")}`;
+    }
+  }
+
+  if (state.sort.length > 0) {
+    const ord = state.sort
+      .filter((s) => s.column)
+      .map((s) => `${quoteIdent(s.column, type)} ${s.dir}`)
+      .join(", ");
+    if (ord) sql += `\nORDER BY ${ord}`;
+  }
+
+  if (state.limit && state.limit > 0) {
+    sql += `\nLIMIT ${Math.floor(state.limit)}`;
+  }
+
+  return sql;
+};
+
+// ── MongoDB ─────────────────────────────────────────────────────────────────
+
+export type MongoOperator =
+  | "$eq"
+  | "$ne"
+  | "$gt"
+  | "$lt"
+  | "$gte"
+  | "$lte"
+  | "$in"
+  | "$nin"
+  | "$exists"
+  | "$regex";
+
+export interface MongoFilter {
+  id: string;
+  field: string;
+  operator: MongoOperator;
+  value: string;
+}
+
+export interface MongoSort {
+  id: string;
+  field: string;
+  dir: 1 | -1;
+}
+
+export interface MongoBuilderState {
+  collection: string | null;
+  filters: MongoFilter[];
+  sort: MongoSort[];
+  limit: number | null;
+  projection: string[]; // empty → no projection
+}
+
+export const emptyMongoBuilderState = (): MongoBuilderState => ({
+  collection: null,
+  filters: [],
+  sort: [],
+  limit: 50,
+  projection: [],
+});
+
+export const MONGO_OPERATORS: MongoOperator[] = [
+  "$eq",
+  "$ne",
+  "$gt",
+  "$lt",
+  "$gte",
+  "$lte",
+  "$in",
+  "$nin",
+  "$exists",
+  "$regex",
+];
+
+const coerceLiteral = (raw: string): unknown => {
+  const trimmed = raw.trim();
+  const kind = inferLiteralKind(trimmed);
+  switch (kind) {
+    case "null":
+      return null;
+    case "number":
+      return Number(trimmed);
+    case "boolean":
+      return trimmed.toLowerCase() === "true";
+    case "string":
+      return trimmed;
+  }
+};
+
+const buildMongoFilterClause = (filter: MongoFilter): unknown => {
+  if (filter.operator === "$exists") {
+    return { $exists: filter.value.trim().toLowerCase() !== "false" };
+  }
+  if (filter.operator === "$regex") {
+    return { $regex: filter.value };
+  }
+  if (filter.operator === "$in" || filter.operator === "$nin") {
+    const items = splitListLiteral(filter.value).map(coerceLiteral);
+    return { [filter.operator]: items };
+  }
+  return { [filter.operator]: coerceLiteral(filter.value) };
+};
+
+export const mongoBuilderToString = (state: MongoBuilderState): string => {
+  if (!state.collection) return "";
+
+  const filterDoc: Record<string, unknown> = {};
+  for (const f of state.filters) {
+    if (!f.field) continue;
+    const clause = buildMongoFilterClause(f);
+    if (filterDoc[f.field]) {
+      // Merge multiple operators on the same field into one nested doc
+      const existing = filterDoc[f.field];
+      if (existing && typeof existing === "object" && clause && typeof clause === "object") {
+        filterDoc[f.field] = { ...existing, ...clause };
+        continue;
+      }
+    }
+    filterDoc[f.field] = clause;
+  }
+
+  const sortDoc: Record<string, 1 | -1> = {};
+  for (const s of state.sort) {
+    if (s.field) sortDoc[s.field] = s.dir;
+  }
+
+  const projectionDoc: Record<string, 1> = {};
+  for (const name of state.projection) {
+    projectionDoc[name] = 1;
+  }
+
+  const command: Record<string, unknown> = {
+    find: state.collection,
+  };
+  if (Object.keys(filterDoc).length > 0) command.filter = filterDoc;
+  if (Object.keys(sortDoc).length > 0) command.sort = sortDoc;
+  if (state.limit && state.limit > 0) command.limit = Math.floor(state.limit);
+  if (Object.keys(projectionDoc).length > 0) command.projection = projectionDoc;
+
+  return JSON.stringify(command, null, 2);
+};
+
+// ── Helpers shared by both ──────────────────────────────────────────────────
+
+export const newId = (): string =>
+  `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+
+export const isSqlType = (type: DatabaseType): boolean => type !== "mongodb";

--- a/apps/mobile/components/builder/builder-state.ts
+++ b/apps/mobile/components/builder/builder-state.ts
@@ -230,6 +230,13 @@ const buildMongoFilterClause = (filter: MongoFilter): unknown | null => {
   }
   if (filter.operator === "$regex") {
     if (trimmed === "") return null;
+    // Validate the pattern client-side so the user gets immediate feedback
+    // instead of a server-side parse error.
+    try {
+      new RegExp(filter.value);
+    } catch {
+      return null;
+    }
     return { $regex: filter.value };
   }
   if (filter.operator === "$in" || filter.operator === "$nin") {

--- a/apps/mobile/components/builder/builder-state.ts
+++ b/apps/mobile/components/builder/builder-state.ts
@@ -141,7 +141,8 @@ export const sqlBuilderToString = (
     if (ord) sql += `\nORDER BY ${ord}`;
   }
 
-  if (state.limit && state.limit > 0) {
+  // `LIMIT 0` is valid SQL — emit it verbatim. Only `null` means "no clause".
+  if (state.limit !== null && state.limit >= 0) {
     sql += `\nLIMIT ${Math.floor(state.limit)}`;
   }
 
@@ -266,7 +267,7 @@ export const mongoBuilderToString = (state: MongoBuilderState): string => {
   };
   if (Object.keys(filterDoc).length > 0) command.filter = filterDoc;
   if (Object.keys(sortDoc).length > 0) command.sort = sortDoc;
-  if (state.limit && state.limit > 0) command.limit = Math.floor(state.limit);
+  if (state.limit !== null && state.limit >= 0) command.limit = Math.floor(state.limit);
   if (Object.keys(projectionDoc).length > 0) command.projection = projectionDoc;
 
   return JSON.stringify(command, null, 2);

--- a/apps/mobile/components/builder/builder-state.ts
+++ b/apps/mobile/components/builder/builder-state.ts
@@ -113,16 +113,15 @@ export const sqlBuilderToString = (state: SqlBuilderState, type: DatabaseType): 
 
   if (state.conditions.length > 0) {
     const parts: string[] = [];
-    state.conditions.forEach((cond, idx) => {
+    for (const cond of state.conditions) {
       const rendered = renderSqlCondition(cond, type);
-      if (!rendered) return;
+      if (!rendered) continue;
       if (parts.length === 0) {
         parts.push(rendered);
       } else {
         parts.push(`${cond.combinator} ${rendered}`);
       }
-      void idx;
-    });
+    }
     if (parts.length > 0) {
       sql += `\nWHERE ${parts.join("\n  ")}`;
     }

--- a/apps/mobile/components/builder/builder-state.ts
+++ b/apps/mobile/components/builder/builder-state.ts
@@ -102,16 +102,11 @@ const renderSqlCondition = (cond: SqlCondition, type: DatabaseType): string | nu
   return `${col} ${cond.operator} ${formatSqlLiteral(cond.value, type)}`;
 };
 
-export const sqlBuilderToString = (
-  state: SqlBuilderState,
-  type: DatabaseType,
-): string => {
+export const sqlBuilderToString = (state: SqlBuilderState, type: DatabaseType): string => {
   if (!state.table) return "";
 
   const cols =
-    state.columns.length === 0
-      ? "*"
-      : state.columns.map((c) => quoteIdent(c, type)).join(", ");
+    state.columns.length === 0 ? "*" : state.columns.map((c) => quoteIdent(c, type)).join(", ");
   const tableRef = quoteQualified(state.table.name, type, state.table.schema);
 
   let sql = `SELECT ${cols}\nFROM ${tableRef}`;

--- a/apps/mobile/components/builder/builder-state.ts
+++ b/apps/mobile/components/builder/builder-state.ts
@@ -220,17 +220,27 @@ const coerceLiteral = (raw: string): unknown => {
   }
 };
 
-const buildMongoFilterClause = (filter: MongoFilter): unknown => {
+// Returns null when the filter should be skipped entirely — e.g. a comparison
+// operator with an empty value, which means the user added the filter but
+// hasn't typed anything yet.
+const buildMongoFilterClause = (filter: MongoFilter): unknown | null => {
+  const trimmed = filter.value.trim();
   if (filter.operator === "$exists") {
-    return { $exists: filter.value.trim().toLowerCase() !== "false" };
+    return { $exists: trimmed.toLowerCase() !== "false" };
   }
   if (filter.operator === "$regex") {
+    if (trimmed === "") return null;
     return { $regex: filter.value };
   }
   if (filter.operator === "$in" || filter.operator === "$nin") {
     const items = splitListLiteral(filter.value).map(coerceLiteral);
+    if (items.length === 0) return null;
     return { [filter.operator]: items };
   }
+  // Comparison operators ($eq/$ne/$gt/$lt/$gte/$lte): empty input means the
+  // user hasn't filled in a value yet, so skip the clause rather than
+  // emitting `{ $eq: "" }` and silently changing the result set.
+  if (trimmed === "") return null;
   return { [filter.operator]: coerceLiteral(filter.value) };
 };
 
@@ -241,6 +251,7 @@ export const mongoBuilderToString = (state: MongoBuilderState): string => {
   for (const f of state.filters) {
     if (!f.field) continue;
     const clause = buildMongoFilterClause(f);
+    if (clause === null) continue;
     if (filterDoc[f.field]) {
       // Merge multiple operators on the same field into one nested doc
       const existing = filterDoc[f.field];

--- a/apps/mobile/components/builder/identifiers.ts
+++ b/apps/mobile/components/builder/identifiers.ts
@@ -33,7 +33,10 @@ export type LiteralKind = "string" | "number" | "boolean" | "null";
 
 export const inferLiteralKind = (raw: string): LiteralKind => {
   const trimmed = raw.trim();
-  if (trimmed === "" || trimmed.toLowerCase() === "null") return "null";
+  // Only the literal "null" (case-insensitive) maps to NULL. An empty input
+  // falls through to "string" so users can express `col = ''` via the builder
+  // (the dedicated IS NULL / IS NOT NULL operators cover null intent).
+  if (trimmed.toLowerCase() === "null") return "null";
   if (trimmed.toLowerCase() === "true" || trimmed.toLowerCase() === "false") return "boolean";
   if (/^-?\d+(\.\d+)?$/.test(trimmed)) return "number";
   return "string";

--- a/apps/mobile/components/builder/identifiers.ts
+++ b/apps/mobile/components/builder/identifiers.ts
@@ -23,10 +23,14 @@ export const quoteQualified = (
   type: DatabaseType,
   schema?: string,
 ): string => {
-  if (schema && schema !== "public") {
-    return `${quoteIdent(schema, type)}.${quoteIdent(name, type)}`;
-  }
-  return quoteIdent(name, type);
+  if (!schema) return quoteIdent(name, type);
+  // "public" is only the implicit default for Postgres/CockroachDB. For
+  // MySQL/MariaDB/SQLite, a database/schema literally named "public" must
+  // still appear in the qualified identifier.
+  const isPgDefaultSchema =
+    (type === "postgres" || type === "cockroachdb") && schema === "public";
+  if (isPgDefaultSchema) return quoteIdent(name, type);
+  return `${quoteIdent(schema, type)}.${quoteIdent(name, type)}`;
 };
 
 export type LiteralKind = "string" | "number" | "boolean" | "null";

--- a/apps/mobile/components/builder/identifiers.ts
+++ b/apps/mobile/components/builder/identifiers.ts
@@ -1,0 +1,68 @@
+import type { DatabaseType } from "../../lib/types";
+
+const SQL_QUOTE: Partial<Record<DatabaseType, [string, string]>> = {
+  postgres: ['"', '"'],
+  cockroachdb: ['"', '"'],
+  sqlite: ['"', '"'],
+  mysql: ["`", "`"],
+  mariadb: ["`", "`"],
+};
+
+const escapeIdentifier = (name: string, close: string): string =>
+  name.replace(new RegExp(close.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"), close + close);
+
+export const quoteIdent = (name: string, type: DatabaseType): string => {
+  const pair = SQL_QUOTE[type];
+  if (!pair) return name;
+  const [open, close] = pair;
+  return `${open}${escapeIdentifier(name, close)}${close}`;
+};
+
+export const quoteQualified = (
+  name: string,
+  type: DatabaseType,
+  schema?: string,
+): string => {
+  if (schema && schema !== "public") {
+    return `${quoteIdent(schema, type)}.${quoteIdent(name, type)}`;
+  }
+  return quoteIdent(name, type);
+};
+
+export type LiteralKind = "string" | "number" | "boolean" | "null";
+
+export const inferLiteralKind = (raw: string): LiteralKind => {
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed.toLowerCase() === "null") return "null";
+  if (trimmed.toLowerCase() === "true" || trimmed.toLowerCase() === "false") return "boolean";
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) return "number";
+  return "string";
+};
+
+const escapeStringLiteral = (raw: string): string => raw.replace(/'/g, "''");
+
+export const formatSqlLiteral = (raw: string, type: DatabaseType): string => {
+  const kind = inferLiteralKind(raw);
+  switch (kind) {
+    case "null":
+      return "NULL";
+    case "number":
+      return raw.trim();
+    case "boolean": {
+      const truthy = raw.trim().toLowerCase() === "true";
+      // MySQL/MariaDB and SQLite accept TRUE/FALSE in modern versions; fall through
+      if (type === "mysql" || type === "mariadb" || type === "sqlite") {
+        return truthy ? "1" : "0";
+      }
+      return truthy ? "TRUE" : "FALSE";
+    }
+    case "string":
+      return `'${escapeStringLiteral(raw)}'`;
+  }
+};
+
+export const splitListLiteral = (raw: string): string[] =>
+  raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);

--- a/apps/mobile/components/builder/identifiers.ts
+++ b/apps/mobile/components/builder/identifiers.ts
@@ -39,7 +39,14 @@ export const inferLiteralKind = (raw: string): LiteralKind => {
   return "string";
 };
 
-const escapeStringLiteral = (raw: string): string => raw.replace(/'/g, "''");
+const escapeStringLiteral = (raw: string, type: DatabaseType): string => {
+  // MySQL/MariaDB treat backslash as an escape character inside '...' strings
+  // unless NO_BACKSLASH_ESCAPES is set (it's not by default). Postgres,
+  // CockroachDB, and SQLite follow the SQL standard — only `'` doubling needed.
+  const needsBackslashEscape = type === "mysql" || type === "mariadb";
+  const backslashEscaped = needsBackslashEscape ? raw.replace(/\\/g, "\\\\") : raw;
+  return backslashEscaped.replace(/'/g, "''");
+};
 
 export const formatSqlLiteral = (raw: string, type: DatabaseType): string => {
   const kind = inferLiteralKind(raw);
@@ -57,7 +64,7 @@ export const formatSqlLiteral = (raw: string, type: DatabaseType): string => {
       return truthy ? "TRUE" : "FALSE";
     }
     case "string":
-      return `'${escapeStringLiteral(raw)}'`;
+      return `'${escapeStringLiteral(raw, type)}'`;
   }
 };
 

--- a/apps/mobile/components/builder/identifiers.ts
+++ b/apps/mobile/components/builder/identifiers.ts
@@ -18,17 +18,12 @@ export const quoteIdent = (name: string, type: DatabaseType): string => {
   return `${open}${escapeIdentifier(name, close)}${close}`;
 };
 
-export const quoteQualified = (
-  name: string,
-  type: DatabaseType,
-  schema?: string,
-): string => {
+export const quoteQualified = (name: string, type: DatabaseType, schema?: string): string => {
   if (!schema) return quoteIdent(name, type);
   // "public" is only the implicit default for Postgres/CockroachDB. For
   // MySQL/MariaDB/SQLite, a database/schema literally named "public" must
   // still appear in the qualified identifier.
-  const isPgDefaultSchema =
-    (type === "postgres" || type === "cockroachdb") && schema === "public";
+  const isPgDefaultSchema = (type === "postgres" || type === "cockroachdb") && schema === "public";
   if (isPgDefaultSchema) return quoteIdent(name, type);
   return `${quoteIdent(schema, type)}.${quoteIdent(name, type)}`;
 };

--- a/apps/mobile/components/results/CardsView.tsx
+++ b/apps/mobile/components/results/CardsView.tsx
@@ -1,0 +1,233 @@
+import { Ionicons } from "@expo/vector-icons";
+import * as Clipboard from "expo-clipboard";
+import { memo, useCallback, useMemo, useState } from "react";
+import { FlatList, Pressable } from "react-native";
+import { Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import { useHaptic } from "../../lib/haptics";
+import type { ColumnInfo } from "../../lib/types";
+import { CellValue } from "./CellValue";
+import { type ResolvedColumns } from "./columnPriority";
+import { previewString, stringifyCell } from "./format";
+
+type CardsViewProps = {
+  rows: Record<string, unknown>[];
+  resolved: ResolvedColumns;
+  onOpenDetail: (row: Record<string, unknown>) => void;
+};
+
+type RowItem = { row: Record<string, unknown>; index: number };
+
+const titleFromRow = (
+  row: Record<string, unknown>,
+  primary: ColumnInfo | null,
+  fallback: ColumnInfo | undefined,
+  index: number,
+): string => {
+  const pkVal = primary ? row[primary.name] : undefined;
+  if (pkVal !== null && pkVal !== undefined && pkVal !== "") {
+    return previewString(pkVal, 24);
+  }
+  if (fallback) {
+    const v = row[fallback.name];
+    if (v !== null && v !== undefined && v !== "") return previewString(v, 24);
+  }
+  return `Row ${index + 1}`;
+};
+
+const FieldRow = memo(function FieldRow({
+  column,
+  row,
+  onOpenDetail,
+}: {
+  column: ColumnInfo;
+  row: Record<string, unknown>;
+  onOpenDetail: (row: Record<string, unknown>) => void;
+}) {
+  return (
+    <XStack alignItems="flex-start" justifyContent="space-between" gap="$sm">
+      <Text
+        color="$placeholderColor"
+        fontSize={11}
+        fontFamily="$mono"
+        textTransform="uppercase"
+        letterSpacing={0.4}
+        flexShrink={0}
+        maxWidth="40%"
+        numberOfLines={1}
+      >
+        {column.name}
+      </Text>
+      <YStack flex={1} alignItems="flex-end">
+        <CellValue
+          column={column}
+          value={row[column.name]}
+          numberOfLines={2}
+          onJsonPress={() => onOpenDetail(row)}
+        />
+      </YStack>
+    </XStack>
+  );
+});
+
+const CardItem = memo(function CardItem({
+  item,
+  resolved,
+  onOpenDetail,
+}: {
+  item: RowItem;
+  resolved: ResolvedColumns;
+  onOpenDetail: (row: Record<string, unknown>) => void;
+}) {
+  const tamagui = useTamaguiTheme();
+  const haptic = useHaptic();
+  const [expanded, setExpanded] = useState(false);
+  const { row, index } = item;
+  const title = titleFromRow(row, resolved.primary, resolved.preview[0], index);
+  const restCount = resolved.rest.length;
+
+  const handleCopy = useCallback(async () => {
+    const obj: Record<string, unknown> = {};
+    for (const c of resolved.visible) obj[c.name] = row[c.name];
+    await Clipboard.setStringAsync(stringifyCell(obj));
+    haptic.light();
+  }, [resolved.visible, row, haptic]);
+
+  return (
+    <YStack
+      backgroundColor="$surface"
+      borderWidth={1}
+      borderColor="$borderColor"
+      borderRadius="$md"
+      padding="$md"
+      gap="$sm"
+      style={{ borderCurve: "continuous" }}
+    >
+      <XStack alignItems="center" justifyContent="space-between" gap="$sm">
+        <XStack
+          backgroundColor="$primaryMuted"
+          borderRadius={999}
+          paddingHorizontal={10}
+          paddingVertical={4}
+          maxWidth="65%"
+        >
+          <Text
+            color="$primary"
+            fontSize={12}
+            fontWeight="600"
+            fontFamily="$mono"
+            numberOfLines={1}
+          >
+            {title}
+          </Text>
+        </XStack>
+        <XStack gap={6}>
+          <Pressable hitSlop={8} onPress={handleCopy}>
+            <YStack
+              width={32}
+              height={32}
+              borderRadius={16}
+              backgroundColor="$surfaceMuted"
+              alignItems="center"
+              justifyContent="center"
+            >
+              <Ionicons name="copy-outline" size={15} color={tamagui.placeholderColor.val} />
+            </YStack>
+          </Pressable>
+          <Pressable hitSlop={8} onPress={() => onOpenDetail(row)}>
+            <YStack
+              width={32}
+              height={32}
+              borderRadius={16}
+              backgroundColor="$surfaceMuted"
+              alignItems="center"
+              justifyContent="center"
+            >
+              <Ionicons name="expand-outline" size={15} color={tamagui.placeholderColor.val} />
+            </YStack>
+          </Pressable>
+        </XStack>
+      </XStack>
+
+      <Pressable onPress={() => onOpenDetail(row)}>
+        <YStack gap="$sm" paddingTop={4}>
+          {resolved.preview.length === 0 ? (
+            <Text color="$placeholderColor" fontSize={12}>
+              No additional fields.
+            </Text>
+          ) : (
+            resolved.preview.map((col) => (
+              <FieldRow key={col.name} column={col} row={row} onOpenDetail={onOpenDetail} />
+            ))
+          )}
+        </YStack>
+      </Pressable>
+
+      {restCount > 0 ? (
+        <>
+          {expanded ? (
+            <YStack gap="$sm" paddingTop={4}>
+              {resolved.rest.map((col) => (
+                <FieldRow key={col.name} column={col} row={row} onOpenDetail={onOpenDetail} />
+              ))}
+            </YStack>
+          ) : null}
+          <Pressable
+            onPress={() => {
+              setExpanded((v) => !v);
+              haptic.light();
+            }}
+          >
+            <XStack alignItems="center" gap={4} paddingTop={4}>
+              <Text color="$primary" fontSize={12} fontWeight="600">
+                {expanded ? "View less" : `View more (${restCount})`}
+              </Text>
+              <Ionicons
+                name={expanded ? "chevron-up" : "chevron-down"}
+                size={14}
+                color={tamagui.primary.val}
+              />
+            </XStack>
+          </Pressable>
+        </>
+      ) : null}
+    </YStack>
+  );
+});
+
+export const CardsView = memo(function CardsView({
+  rows,
+  resolved,
+  onOpenDetail,
+}: CardsViewProps) {
+  const data = useMemo(
+    () => rows.map((row, index): RowItem => ({ row, index })),
+    [rows],
+  );
+
+  if (rows.length === 0) {
+    return (
+      <YStack flex={1} alignItems="center" justifyContent="center" padding="$lg" gap="$sm">
+        <Ionicons name="albums-outline" size={28} color="#8a8aa0" />
+        <Text color="$placeholderColor" fontSize={14}>
+          No rows match the current view.
+        </Text>
+      </YStack>
+    );
+  }
+
+  return (
+    <FlatList
+      data={data}
+      keyExtractor={(item) => `row-${item.index}`}
+      contentContainerStyle={{ gap: 10, paddingBottom: 24 }}
+      renderItem={({ item }) => (
+        <CardItem item={item} resolved={resolved} onOpenDetail={onOpenDetail} />
+      )}
+      removeClippedSubviews
+      initialNumToRender={12}
+      windowSize={9}
+      maxToRenderPerBatch={10}
+      showsVerticalScrollIndicator={false}
+    />
+  );
+});

--- a/apps/mobile/components/results/CardsView.tsx
+++ b/apps/mobile/components/results/CardsView.tsx
@@ -6,7 +6,7 @@ import { Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
 import { useHaptic } from "../../lib/haptics";
 import type { ColumnInfo } from "../../lib/types";
 import { CellValue } from "./CellValue";
-import { type ResolvedColumns } from "./columnPriority";
+import type { ResolvedColumns } from "./columnPriority";
 import { previewString, stringifyCell } from "./format";
 
 type CardsViewProps = {
@@ -209,11 +209,7 @@ const CardItem = memo(function CardItem({
   );
 });
 
-export const CardsView = memo(function CardsView({
-  rows,
-  resolved,
-  onOpenDetail,
-}: CardsViewProps) {
+export const CardsView = memo(function CardsView({ rows, resolved, onOpenDetail }: CardsViewProps) {
   const data = useMemo(
     () =>
       rows.map(

--- a/apps/mobile/components/results/CardsView.tsx
+++ b/apps/mobile/components/results/CardsView.tsx
@@ -22,9 +22,14 @@ const stableRowKey = (
   primary: ColumnInfo | null,
   index: number,
 ): string => {
-    if (v !== null && v !== undefined && v !== "") return `pk:${String(v)}-${index}`;
+  if (primary) {
     const v = row[primary.name];
-    if (v !== null && v !== undefined && v !== "") return `pk:${String(v)}`;
+    if (v !== null && v !== undefined && v !== "") {
+      // Suffix the index so two rows with the same PK value (rare but
+      // possible from joins or hand-crafted SELECTs) don't collide as
+      // React keys.
+      return `pk:${String(v)}-${index}`;
+    }
   }
   // Fall back to index only when the result has no detectable PK. CardItem
   // expanded state will follow the position in that case, but there's no

--- a/apps/mobile/components/results/CardsView.tsx
+++ b/apps/mobile/components/results/CardsView.tsx
@@ -22,7 +22,7 @@ const stableRowKey = (
   primary: ColumnInfo | null,
   index: number,
 ): string => {
-  if (primary) {
+    if (v !== null && v !== undefined && v !== "") return `pk:${String(v)}-${index}`;
     const v = row[primary.name];
     if (v !== null && v !== undefined && v !== "") return `pk:${String(v)}`;
   }

--- a/apps/mobile/components/results/CardsView.tsx
+++ b/apps/mobile/components/results/CardsView.tsx
@@ -15,7 +15,22 @@ type CardsViewProps = {
   onOpenDetail: (row: Record<string, unknown>) => void;
 };
 
-type RowItem = { row: Record<string, unknown>; index: number };
+type RowItem = { row: Record<string, unknown>; index: number; key: string };
+
+const stableRowKey = (
+  row: Record<string, unknown>,
+  primary: ColumnInfo | null,
+  index: number,
+): string => {
+  if (primary) {
+    const v = row[primary.name];
+    if (v !== null && v !== undefined && v !== "") return `pk:${String(v)}`;
+  }
+  // Fall back to index only when the result has no detectable PK. CardItem
+  // expanded state will follow the position in that case, but there's no
+  // stabler identity available.
+  return `idx:${index}`;
+};
 
 const titleFromRow = (
   row: Record<string, unknown>,
@@ -200,8 +215,15 @@ export const CardsView = memo(function CardsView({
   onOpenDetail,
 }: CardsViewProps) {
   const data = useMemo(
-    () => rows.map((row, index): RowItem => ({ row, index })),
-    [rows],
+    () =>
+      rows.map(
+        (row, index): RowItem => ({
+          row,
+          index,
+          key: stableRowKey(row, resolved.primary, index),
+        }),
+      ),
+    [rows, resolved.primary],
   );
 
   if (rows.length === 0) {
@@ -218,7 +240,7 @@ export const CardsView = memo(function CardsView({
   return (
     <FlatList
       data={data}
-      keyExtractor={(item) => `row-${item.index}`}
+      keyExtractor={(item) => item.key}
       contentContainerStyle={{ gap: 10, paddingBottom: 24 }}
       renderItem={({ item }) => (
         <CardItem item={item} resolved={resolved} onOpenDetail={onOpenDetail} />

--- a/apps/mobile/components/results/CellValue.tsx
+++ b/apps/mobile/components/results/CellValue.tsx
@@ -1,0 +1,125 @@
+import { Ionicons } from "@expo/vector-icons";
+import { memo, useState } from "react";
+import { Pressable } from "react-native";
+import { Text, useTheme as useTamaguiTheme, XStack } from "tamagui";
+import { useHaptic } from "../../lib/haptics";
+import type { ColumnInfo } from "../../lib/types";
+import {
+  cellKind,
+  formatDate,
+  formatNumberCompact,
+  formatNumberExact,
+  previewString,
+  truthyBoolean,
+} from "./format";
+
+type CellValueProps = {
+  column: ColumnInfo;
+  value: unknown;
+  numberOfLines?: number;
+  onJsonPress?: (value: unknown, column: ColumnInfo) => void;
+};
+
+export const CellValue = memo(function CellValue({
+  column,
+  value,
+  numberOfLines = 1,
+  onJsonPress,
+}: CellValueProps) {
+  const tamagui = useTamaguiTheme();
+  const haptic = useHaptic();
+  const [showExact, setShowExact] = useState(false);
+  const kind = cellKind(column, value);
+
+  if (kind === "null") {
+    return (
+      <Text color="$placeholderColor" fontSize={13}>
+        —
+      </Text>
+    );
+  }
+
+  if (kind === "boolean") {
+    const truthy = truthyBoolean(value);
+    return (
+      <Ionicons
+        name={truthy ? "checkmark-circle" : "close-circle"}
+        size={16}
+        color={truthy ? tamagui.success.val : tamagui.placeholderColor.val}
+      />
+    );
+  }
+
+  if (kind === "number") {
+    const n = typeof value === "number" ? value : Number(value);
+    if (!Number.isFinite(n)) {
+      return (
+        <Text color="$color" fontSize={13} numberOfLines={numberOfLines} selectable>
+          {String(value)}
+        </Text>
+      );
+    }
+    const display = showExact ? formatNumberExact(n) : formatNumberCompact(n);
+    const isCompact = display !== formatNumberExact(n);
+    return (
+      <Pressable
+        onLongPress={() => {
+          if (isCompact) {
+            haptic.light();
+            setShowExact(true);
+            setTimeout(() => setShowExact(false), 2500);
+          }
+        }}
+        delayLongPress={300}
+      >
+        <Text
+          color="$color"
+          fontSize={13}
+          fontFamily="$mono"
+          fontVariant={["tabular-nums"]}
+          numberOfLines={numberOfLines}
+          selectable
+        >
+          {display}
+        </Text>
+      </Pressable>
+    );
+  }
+
+  if (kind === "date") {
+    return (
+      <Text color="$color" fontSize={13} numberOfLines={numberOfLines} selectable>
+        {formatDate(value)}
+      </Text>
+    );
+  }
+
+  if (kind === "json") {
+    return (
+      <Pressable onPress={() => onJsonPress?.(value, column)} hitSlop={6}>
+        <XStack
+          alignItems="center"
+          gap={4}
+          paddingHorizontal={6}
+          paddingVertical={2}
+          backgroundColor="$surfaceMuted"
+          borderRadius="$xs"
+          alignSelf="flex-start"
+        >
+          <Text color="$placeholderColor" fontSize={11} fontFamily="$mono">
+            {"{…}"}
+          </Text>
+          <Text color="$placeholderColor" fontSize={11}>
+            JSON
+          </Text>
+        </XStack>
+      </Pressable>
+    );
+  }
+
+  return (
+    <Text color="$color" fontSize={13} numberOfLines={numberOfLines} selectable>
+      {previewString(value, 200)}
+    </Text>
+  );
+});

--- a/apps/mobile/components/results/CellValue.tsx
+++ b/apps/mobile/components/results/CellValue.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
-import { memo, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { Pressable } from "react-native";
 import { Text, useTheme as useTamaguiTheme, XStack } from "tamagui";
 import { useHaptic } from "../../lib/haptics";
@@ -30,6 +30,15 @@ export const CellValue = memo(function CellValue({
   const haptic = useHaptic();
   const [showExact, setShowExact] = useState(false);
   const kind = cellKind(column, value);
+
+  // Auto-revert the long-press "exact value" reveal after a short window. An
+  // effect-driven timer cancels itself if the cell is virtualized away or the
+  // user long-presses again before it fires, avoiding stale-state writes.
+  useEffect(() => {
+    if (!showExact) return;
+    const id = setTimeout(() => setShowExact(false), 2500);
+    return () => clearTimeout(id);
+  }, [showExact]);
 
   if (kind === "null") {
     return (
@@ -67,7 +76,6 @@ export const CellValue = memo(function CellValue({
           if (isCompact) {
             haptic.light();
             setShowExact(true);
-            setTimeout(() => setShowExact(false), 2500);
           }
         }}
         delayLongPress={300}

--- a/apps/mobile/components/results/ColumnCustomizeSheet.tsx
+++ b/apps/mobile/components/results/ColumnCustomizeSheet.tsx
@@ -3,8 +3,8 @@ import { memo, useCallback } from "react";
 import { Pressable, ScrollView } from "react-native";
 import { Sheet, Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
 import { useHaptic } from "../../lib/haptics";
-import type { ColumnInfo } from "../../lib/types";
 import type { ColumnPrefs } from "../../lib/storage/results-prefs";
+import type { ColumnInfo } from "../../lib/types";
 
 type ColumnCustomizeSheetProps = {
   open: boolean;

--- a/apps/mobile/components/results/ColumnCustomizeSheet.tsx
+++ b/apps/mobile/components/results/ColumnCustomizeSheet.tsx
@@ -1,0 +1,176 @@
+import { Ionicons } from "@expo/vector-icons";
+import { memo, useCallback } from "react";
+import { Pressable, ScrollView } from "react-native";
+import { Sheet, Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import { useHaptic } from "../../lib/haptics";
+import type { ColumnInfo } from "../../lib/types";
+import type { ColumnPrefs } from "../../lib/storage/results-prefs";
+
+type ColumnCustomizeSheetProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  columns: ColumnInfo[];
+  prefs: ColumnPrefs;
+  onChange: (prefs: ColumnPrefs) => void;
+  onReset: () => void;
+};
+
+const togglePin = (prefs: ColumnPrefs, name: string): ColumnPrefs => {
+  const isPinned = prefs.pinned.includes(name);
+  return {
+    pinned: isPinned ? prefs.pinned.filter((n) => n !== name) : [...prefs.pinned, name],
+    hidden: prefs.hidden.filter((n) => n !== name),
+  };
+};
+
+const toggleHide = (prefs: ColumnPrefs, name: string): ColumnPrefs => {
+  const isHidden = prefs.hidden.includes(name);
+  return {
+    pinned: prefs.pinned.filter((n) => n !== name),
+    hidden: isHidden ? prefs.hidden.filter((n) => n !== name) : [...prefs.hidden, name],
+  };
+};
+
+export const ColumnCustomizeSheet = memo(function ColumnCustomizeSheet({
+  open,
+  onOpenChange,
+  columns,
+  prefs,
+  onChange,
+  onReset,
+}: ColumnCustomizeSheetProps) {
+  const tamagui = useTamaguiTheme();
+  const haptic = useHaptic();
+
+  const handlePin = useCallback(
+    (name: string) => {
+      haptic.light();
+      onChange(togglePin(prefs, name));
+    },
+    [prefs, onChange, haptic],
+  );
+
+  const handleHide = useCallback(
+    (name: string) => {
+      haptic.light();
+      onChange(toggleHide(prefs, name));
+    },
+    [prefs, onChange, haptic],
+  );
+
+  return (
+    <Sheet
+      modal
+      open={open}
+      onOpenChange={onOpenChange}
+      animation="medium"
+      zIndex={200000}
+      dismissOnSnapToBottom
+      snapPoints={[80]}
+    >
+      <Sheet.Overlay
+        animation="lazy"
+        enterStyle={{ opacity: 0 }}
+        exitStyle={{ opacity: 0 }}
+        backgroundColor="$dialogOverlay"
+      />
+      <Sheet.Frame
+        backgroundColor="$surfaceElevated"
+        borderTopLeftRadius={20}
+        borderTopRightRadius={20}
+        padding="$lg"
+        gap="$md"
+      >
+        <Sheet.Handle backgroundColor="$dialogHandle" alignSelf="center" />
+        <XStack alignItems="center" justifyContent="space-between">
+          <YStack gap={2}>
+            <Text fontSize={17} fontWeight="600" color="$color" letterSpacing={-0.2}>
+              Customize fields
+            </Text>
+            <Text color="$placeholderColor" fontSize={12}>
+              Pin to force show. Hide to omit from cards.
+            </Text>
+          </YStack>
+          <Pressable hitSlop={10} onPress={onReset}>
+            <Text color="$primary" fontSize={13} fontWeight="600">
+              Reset
+            </Text>
+          </Pressable>
+        </XStack>
+
+        <ScrollView showsVerticalScrollIndicator={false}>
+          <YStack gap={6} paddingBottom={32}>
+            {columns.map((col) => {
+              const isPinned = prefs.pinned.includes(col.name);
+              const isHidden = prefs.hidden.includes(col.name);
+              return (
+                <XStack
+                  key={col.name}
+                  alignItems="center"
+                  justifyContent="space-between"
+                  paddingHorizontal="$sm"
+                  paddingVertical="$sm"
+                  backgroundColor="$surface"
+                  borderRadius="$sm"
+                  borderWidth={1}
+                  borderColor="$borderColor"
+                  gap="$sm"
+                >
+                  <YStack flex={1} gap={2}>
+                    <Text color="$color" fontSize={14} fontWeight="500" numberOfLines={1}>
+                      {col.name}
+                    </Text>
+                    {col.type ? (
+                      <Text
+                        color="$placeholderColor"
+                        fontSize={11}
+                        fontFamily="$mono"
+                        numberOfLines={1}
+                      >
+                        {col.type.toLowerCase()}
+                      </Text>
+                    ) : null}
+                  </YStack>
+                  <XStack gap={6}>
+                    <Pressable hitSlop={6} onPress={() => handlePin(col.name)}>
+                      <YStack
+                        width={36}
+                        height={36}
+                        borderRadius={10}
+                        backgroundColor={isPinned ? "$primaryMuted" : "$surfaceMuted"}
+                        alignItems="center"
+                        justifyContent="center"
+                      >
+                        <Ionicons
+                          name={isPinned ? "pin" : "pin-outline"}
+                          size={16}
+                          color={isPinned ? tamagui.primary.val : tamagui.placeholderColor.val}
+                        />
+                      </YStack>
+                    </Pressable>
+                    <Pressable hitSlop={6} onPress={() => handleHide(col.name)}>
+                      <YStack
+                        width={36}
+                        height={36}
+                        borderRadius={10}
+                        backgroundColor={isHidden ? "$dangerMuted" : "$surfaceMuted"}
+                        alignItems="center"
+                        justifyContent="center"
+                      >
+                        <Ionicons
+                          name={isHidden ? "eye-off" : "eye-outline"}
+                          size={16}
+                          color={isHidden ? tamagui.danger.val : tamagui.placeholderColor.val}
+                        />
+                      </YStack>
+                    </Pressable>
+                  </XStack>
+                </XStack>
+              );
+            })}
+          </YStack>
+        </ScrollView>
+      </Sheet.Frame>
+    </Sheet>
+  );
+});

--- a/apps/mobile/components/results/ColumnCustomizeSheet.tsx
+++ b/apps/mobile/components/results/ColumnCustomizeSheet.tsx
@@ -91,7 +91,12 @@ export const ColumnCustomizeSheet = memo(function ColumnCustomizeSheet({
               Pin to force show. Hide to omit from cards.
             </Text>
           </YStack>
-          <Pressable hitSlop={10} onPress={onReset}>
+          <Pressable
+            hitSlop={10}
+            onPress={onReset}
+            accessibilityRole="button"
+            accessibilityLabel="Reset column customization"
+          >
             <Text color="$primary" fontSize={13} fontWeight="600">
               Reset
             </Text>
@@ -100,12 +105,16 @@ export const ColumnCustomizeSheet = memo(function ColumnCustomizeSheet({
 
         <ScrollView showsVerticalScrollIndicator={false}>
           <YStack gap={6} paddingBottom={32}>
-            {columns.map((col) => {
+            {columns.map((col, idx) => {
               const isPinned = prefs.pinned.includes(col.name);
               const isHidden = prefs.hidden.includes(col.name);
               return (
                 <XStack
-                  key={col.name}
+                  // Suffix the index so duplicate column names from a join
+                  // without aliases don't collide as React keys. Pin/hide
+                  // prefs themselves are still keyed by display name —
+                  // duplicates share the same toggle state by design.
+                  key={`${col.name}-${idx}`}
                   alignItems="center"
                   justifyContent="space-between"
                   paddingHorizontal="$sm"
@@ -132,7 +141,13 @@ export const ColumnCustomizeSheet = memo(function ColumnCustomizeSheet({
                     ) : null}
                   </YStack>
                   <XStack gap={6}>
-                    <Pressable hitSlop={6} onPress={() => handlePin(col.name)}>
+                    <Pressable
+                      hitSlop={6}
+                      onPress={() => handlePin(col.name)}
+                      accessibilityRole="button"
+                      accessibilityLabel={isPinned ? `Unpin ${col.name}` : `Pin ${col.name}`}
+                      accessibilityState={{ selected: isPinned }}
+                    >
                       <YStack
                         width={36}
                         height={36}
@@ -148,7 +163,13 @@ export const ColumnCustomizeSheet = memo(function ColumnCustomizeSheet({
                         />
                       </YStack>
                     </Pressable>
-                    <Pressable hitSlop={6} onPress={() => handleHide(col.name)}>
+                    <Pressable
+                      hitSlop={6}
+                      onPress={() => handleHide(col.name)}
+                      accessibilityRole="button"
+                      accessibilityLabel={isHidden ? `Show ${col.name}` : `Hide ${col.name}`}
+                      accessibilityState={{ selected: isHidden }}
+                    >
                       <YStack
                         width={36}
                         height={36}

--- a/apps/mobile/components/results/DetailSheet.tsx
+++ b/apps/mobile/components/results/DetailSheet.tsx
@@ -110,12 +110,7 @@ export const DetailSheet = memo(function DetailSheet({
                     </XStack>
                     <YStack>
                       {value !== null && value !== undefined && typeof value === "object" ? (
-                        <Text
-                          color="$color"
-                          fontSize={12}
-                          fontFamily="$mono"
-                          selectable
-                        >
+                        <Text color="$color" fontSize={12} fontFamily="$mono" selectable>
                           {stringifyCell(value)}
                         </Text>
                       ) : (

--- a/apps/mobile/components/results/DetailSheet.tsx
+++ b/apps/mobile/components/results/DetailSheet.tsx
@@ -1,0 +1,134 @@
+import { Ionicons } from "@expo/vector-icons";
+import * as Clipboard from "expo-clipboard";
+import { memo, useCallback } from "react";
+import { Pressable, ScrollView } from "react-native";
+import { Sheet, Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import { useHaptic } from "../../lib/haptics";
+import type { ColumnInfo } from "../../lib/types";
+import { CellValue } from "./CellValue";
+import { stringifyCell } from "./format";
+
+type DetailSheetProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  columns: ColumnInfo[];
+  row: Record<string, unknown> | null;
+  title?: string;
+};
+
+export const DetailSheet = memo(function DetailSheet({
+  open,
+  onOpenChange,
+  columns,
+  row,
+  title,
+}: DetailSheetProps) {
+  const tamagui = useTamaguiTheme();
+  const haptic = useHaptic();
+
+  const copyValue = useCallback(
+    async (value: unknown) => {
+      await Clipboard.setStringAsync(stringifyCell(value));
+      haptic.light();
+    },
+    [haptic],
+  );
+
+  return (
+    <Sheet
+      modal
+      open={open}
+      onOpenChange={onOpenChange}
+      animation="medium"
+      zIndex={200000}
+      dismissOnSnapToBottom
+      snapPoints={[88, 60]}
+    >
+      <Sheet.Overlay
+        animation="lazy"
+        enterStyle={{ opacity: 0 }}
+        exitStyle={{ opacity: 0 }}
+        backgroundColor="$dialogOverlay"
+      />
+      <Sheet.Frame
+        backgroundColor="$surfaceElevated"
+        borderTopLeftRadius={20}
+        borderTopRightRadius={20}
+        padding="$lg"
+        gap="$md"
+      >
+        <Sheet.Handle backgroundColor="$dialogHandle" alignSelf="center" />
+        <XStack alignItems="center" justifyContent="space-between">
+          <Text fontSize={17} fontWeight="600" color="$color" letterSpacing={-0.2}>
+            {title ?? "Row details"}
+          </Text>
+          <Pressable hitSlop={10} onPress={() => onOpenChange(false)}>
+            <Ionicons name="close" size={22} color={tamagui.placeholderColor.val} />
+          </Pressable>
+        </XStack>
+
+        <ScrollView showsVerticalScrollIndicator={false}>
+          <YStack gap="$sm" paddingBottom={32}>
+            {row === null ? (
+              <Text color="$placeholderColor" fontSize={14}>
+                No row selected.
+              </Text>
+            ) : (
+              columns.map((col) => {
+                const value = row[col.name];
+                return (
+                  <YStack
+                    key={col.name}
+                    gap={4}
+                    paddingVertical="$sm"
+                    paddingHorizontal="$sm"
+                    backgroundColor="$surface"
+                    borderRadius="$sm"
+                    borderWidth={1}
+                    borderColor="$borderColor"
+                  >
+                    <XStack alignItems="center" justifyContent="space-between" gap="$sm">
+                      <YStack flex={1} gap={2}>
+                        <Text
+                          color="$placeholderColor"
+                          fontSize={11}
+                          fontFamily="$mono"
+                          textTransform="uppercase"
+                          letterSpacing={0.4}
+                        >
+                          {col.name}
+                          {col.type ? `  ·  ${col.type.toLowerCase()}` : ""}
+                        </Text>
+                      </YStack>
+                      <Pressable hitSlop={8} onPress={() => copyValue(value)}>
+                        <Ionicons
+                          name="copy-outline"
+                          size={16}
+                          color={tamagui.placeholderColor.val}
+                        />
+                      </Pressable>
+                    </XStack>
+                    <YStack>
+                      {value !== null && value !== undefined && typeof value === "object" ? (
+                        <Text
+                          color="$color"
+                          fontSize={12}
+                          fontFamily="$mono"
+                          selectable
+                        >
+                          {stringifyCell(value)}
+                        </Text>
+                      ) : (
+                        <CellValue column={col} value={value} numberOfLines={6} />
+                      )}
+                    </YStack>
+                  </YStack>
+                );
+              })
+            )}
+          </YStack>
+        </ScrollView>
+      </Sheet.Frame>
+    </Sheet>
+  );
+});

--- a/apps/mobile/components/results/JsonView.tsx
+++ b/apps/mobile/components/results/JsonView.tsx
@@ -42,12 +42,7 @@ const JsonNode = memo(function JsonNode({
   }, [data, haptic]);
 
   if (PRIMITIVE(data)) {
-    const display =
-      data === null
-        ? "null"
-        : typeof data === "string"
-          ? `"${data}"`
-          : String(data);
+    const display = data === null ? "null" : typeof data === "string" ? `"${data}"` : String(data);
     const color =
       data === null
         ? TYPE_COLOR.null
@@ -82,11 +77,7 @@ const JsonNode = memo(function JsonNode({
 
   return (
     <YStack>
-      <Pressable
-        onPress={() => setOpen((v) => !v)}
-        onLongPress={copy}
-        delayLongPress={350}
-      >
+      <Pressable onPress={() => setOpen((v) => !v)} onLongPress={copy} delayLongPress={350}>
         <XStack paddingLeft={depth * 12} alignItems="center" gap={6} paddingVertical={2}>
           <Ionicons
             name={open2 ? "chevron-down" : "chevron-forward"}

--- a/apps/mobile/components/results/JsonView.tsx
+++ b/apps/mobile/components/results/JsonView.tsx
@@ -37,8 +37,14 @@ const JsonNode = memo(function JsonNode({
   const [open, setOpen] = useState(defaultOpen);
 
   const copy = useCallback(async () => {
-    await Clipboard.setStringAsync(stringifyJson(data));
-    haptic.light();
+    try {
+      await Clipboard.setStringAsync(stringifyJson(data));
+      haptic.light();
+    } catch {
+      // Clipboard write can throw on Android (permission denied) or when
+      // the native module isn't available; swallow so the long-press
+      // doesn't surface as an unhandled rejection.
+    }
   }, [data, haptic]);
 
   if (PRIMITIVE(data)) {

--- a/apps/mobile/components/results/JsonView.tsx
+++ b/apps/mobile/components/results/JsonView.tsx
@@ -1,0 +1,154 @@
+import { Ionicons } from "@expo/vector-icons";
+import * as Clipboard from "expo-clipboard";
+import { memo, useCallback, useState } from "react";
+import { Pressable, ScrollView } from "react-native";
+import { Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import { useHaptic } from "../../lib/haptics";
+import type { ColumnInfo } from "../../lib/types";
+import { stringifyJson } from "./format";
+
+type JsonViewProps = {
+  rows: Record<string, unknown>[];
+  columns: ColumnInfo[];
+};
+
+const TYPE_COLOR: Record<string, string> = {
+  string: "$success",
+  number: "$warning",
+  boolean: "$primary",
+  null: "$placeholderColor",
+};
+
+const PRIMITIVE = (v: unknown) => v === null || (typeof v !== "object" && typeof v !== "function");
+
+const JsonNode = memo(function JsonNode({
+  data,
+  name,
+  depth,
+  defaultOpen,
+}: {
+  data: unknown;
+  name?: string;
+  depth: number;
+  defaultOpen: boolean;
+}) {
+  const tamagui = useTamaguiTheme();
+  const haptic = useHaptic();
+  const [open, setOpen] = useState(defaultOpen);
+
+  const copy = useCallback(async () => {
+    await Clipboard.setStringAsync(stringifyJson(data));
+    haptic.light();
+  }, [data, haptic]);
+
+  if (PRIMITIVE(data)) {
+    const display =
+      data === null
+        ? "null"
+        : typeof data === "string"
+          ? `"${data}"`
+          : String(data);
+    const color =
+      data === null
+        ? TYPE_COLOR.null
+        : typeof data === "string"
+          ? TYPE_COLOR.string
+          : typeof data === "number"
+            ? TYPE_COLOR.number
+            : typeof data === "boolean"
+              ? TYPE_COLOR.boolean
+              : "$color";
+    return (
+      <Pressable onLongPress={copy} delayLongPress={300}>
+        <XStack paddingLeft={depth * 12} alignItems="center" gap={6} paddingVertical={2}>
+          {name !== undefined ? (
+            <Text color="$placeholderColor" fontSize={12} fontFamily="$mono" selectable>
+              {name}:
+            </Text>
+          ) : null}
+          <Text color={color} fontSize={12} fontFamily="$mono" selectable numberOfLines={1}>
+            {display}
+          </Text>
+        </XStack>
+      </Pressable>
+    );
+  }
+
+  const isArray = Array.isArray(data);
+  const entries = isArray
+    ? (data as unknown[]).map((v, i) => [String(i), v] as const)
+    : Object.entries(data as Record<string, unknown>);
+  const open2 = open;
+
+  return (
+    <YStack>
+      <Pressable
+        onPress={() => setOpen((v) => !v)}
+        onLongPress={copy}
+        delayLongPress={350}
+      >
+        <XStack paddingLeft={depth * 12} alignItems="center" gap={6} paddingVertical={2}>
+          <Ionicons
+            name={open2 ? "chevron-down" : "chevron-forward"}
+            size={12}
+            color={tamagui.placeholderColor.val}
+          />
+          {name !== undefined ? (
+            <Text color="$placeholderColor" fontSize={12} fontFamily="$mono">
+              {name}:
+            </Text>
+          ) : null}
+          <Text color="$color" fontSize={12} fontFamily="$mono">
+            {isArray ? `[ ${entries.length} ]` : `{ ${entries.length} }`}
+          </Text>
+        </XStack>
+      </Pressable>
+      {open2
+        ? entries.map(([k, v]) => (
+            <JsonNode
+              key={`${depth}-${k}`}
+              data={v}
+              name={isArray ? `[${k}]` : k}
+              depth={depth + 1}
+              defaultOpen={depth < 1}
+            />
+          ))
+        : null}
+    </YStack>
+  );
+});
+
+export const JsonView = memo(function JsonView({ rows, columns }: JsonViewProps) {
+  const data = rows.map((row) => {
+    const obj: Record<string, unknown> = {};
+    for (const col of columns) obj[col.name] = row[col.name];
+    return obj;
+  });
+
+  if (rows.length === 0) {
+    return (
+      <YStack flex={1} alignItems="center" justifyContent="center" padding="$lg" gap="$sm">
+        <Ionicons name="code-slash-outline" size={28} color="#8a8aa0" />
+        <Text color="$placeholderColor" fontSize={14}>
+          No rows match the current view.
+        </Text>
+      </YStack>
+    );
+  }
+
+  return (
+    <ScrollView showsVerticalScrollIndicator={false}>
+      <YStack
+        backgroundColor="$surface"
+        borderWidth={1}
+        borderColor="$borderColor"
+        borderRadius="$md"
+        padding="$sm"
+        paddingBottom="$lg"
+        style={{ borderCurve: "continuous" }}
+      >
+        <JsonNode data={data} depth={0} defaultOpen />
+      </YStack>
+    </ScrollView>
+  );
+});

--- a/apps/mobile/components/results/ResultsView.tsx
+++ b/apps/mobile/components/results/ResultsView.tsx
@@ -14,12 +14,12 @@ import {
 } from "../../lib/storage/results-prefs";
 import type { QueryResult } from "../../lib/types";
 import { CardsView } from "./CardsView";
+import { ColumnCustomizeSheet } from "./ColumnCustomizeSheet";
 import { resolveColumns } from "./columnPriority";
 import { DetailSheet } from "./DetailSheet";
-import { ColumnCustomizeSheet } from "./ColumnCustomizeSheet";
 import { isNullish, stringifyCell } from "./format";
 import { JsonView } from "./JsonView";
-import { SortSheet, type SortDir } from "./SortSheet";
+import { type SortDir, SortSheet } from "./SortSheet";
 import { TableView } from "./TableView";
 
 type ResultsViewProps = {
@@ -96,11 +96,7 @@ const ViewSwitcher = memo(function ViewSwitcher({
                 size={13}
                 color={active ? tamagui.color.val : tamagui.placeholderColor.val}
               />
-              <Text
-                color={active ? "$color" : "$placeholderColor"}
-                fontSize={11}
-                fontWeight="600"
-              >
+              <Text color={active ? "$color" : "$placeholderColor"} fontSize={11} fontWeight="600">
                 {item.label}
               </Text>
             </XStack>
@@ -196,9 +192,7 @@ export const ResultsView = memo(function ResultsView({
 
   const displayRows = useMemo(() => {
     if (!sortColumn || !sortDir) return filteredRows;
-    const sorted = [...filteredRows].sort((a, b) =>
-      compareValues(a[sortColumn], b[sortColumn]),
-    );
+    const sorted = [...filteredRows].sort((a, b) => compareValues(a[sortColumn], b[sortColumn]));
     if (sortDir === "desc") sorted.reverse();
     return sorted;
   }, [filteredRows, sortColumn, sortDir]);
@@ -228,20 +222,13 @@ export const ResultsView = memo(function ResultsView({
 
   if (result.columns.length === 0) {
     return (
-      <XStack
-        alignItems="center"
-        gap="$sm"
-        paddingVertical="$lg"
-        paddingHorizontal="$xs"
-      >
+      <XStack alignItems="center" gap="$sm" paddingVertical="$lg" paddingHorizontal="$xs">
         <Text color="$success" fontSize={18} fontWeight="600">
           ✓
         </Text>
         <Text color="$textMuted" fontSize={14}>
           {result.rowCount > 0
-            ? `${result.rowCount.toLocaleString()} row${
-                result.rowCount === 1 ? "" : "s"
-              } affected`
+            ? `${result.rowCount.toLocaleString()} row${result.rowCount === 1 ? "" : "s"} affected`
             : "Query executed successfully"}
         </Text>
       </XStack>
@@ -310,11 +297,7 @@ export const ResultsView = memo(function ResultsView({
             />
             {search ? (
               <Pressable hitSlop={6} onPress={() => setSearch("")}>
-                <Ionicons
-                  name="close-circle"
-                  size={14}
-                  color={tamagui.placeholderColor.val}
-                />
+                <Ionicons name="close-circle" size={14} color={tamagui.placeholderColor.val} />
               </Pressable>
             ) : null}
           </XStack>
@@ -373,13 +356,7 @@ export const ResultsView = memo(function ResultsView({
 
       <YStack flex={1}>
         {result.rows.length === 0 ? (
-          <YStack
-            flex={1}
-            alignItems="center"
-            justifyContent="center"
-            padding="$lg"
-            gap="$sm"
-          >
+          <YStack flex={1} alignItems="center" justifyContent="center" padding="$lg" gap="$sm">
             <Ionicons name="leaf-outline" size={28} color={tamagui.placeholderColor.val} />
             <Text color="$color" fontSize={15} fontWeight="600">
               No rows returned

--- a/apps/mobile/components/results/ResultsView.tsx
+++ b/apps/mobile/components/results/ResultsView.tsx
@@ -1,0 +1,438 @@
+import { Ionicons } from "@expo/vector-icons";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { Pressable, TextInput } from "react-native";
+import { Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import { useHaptic } from "../../lib/haptics";
+import {
+  buildPrefsKey,
+  type ColumnPrefs,
+  getColumnPrefs,
+  getResultsViewMode,
+  type ResultsViewMode,
+  setColumnPrefs,
+  setResultsViewMode,
+} from "../../lib/storage/results-prefs";
+import type { QueryResult } from "../../lib/types";
+import { CardsView } from "./CardsView";
+import { resolveColumns } from "./columnPriority";
+import { DetailSheet } from "./DetailSheet";
+import { ColumnCustomizeSheet } from "./ColumnCustomizeSheet";
+import { isNullish, stringifyCell } from "./format";
+import { JsonView } from "./JsonView";
+import { SortSheet, type SortDir } from "./SortSheet";
+import { TableView } from "./TableView";
+
+type ResultsViewProps = {
+  result: QueryResult;
+  connectionId: string;
+  query: string;
+  onCopyAll: () => void;
+};
+
+const cellSearchString = (value: unknown): string => {
+  if (isNullish(value)) return "";
+  if (typeof value === "object") return stringifyCell(value).toLowerCase();
+  return String(value).toLowerCase();
+};
+
+const compareValues = (a: unknown, b: unknown): number => {
+  const an = isNullish(a);
+  const bn = isNullish(b);
+  if (an && bn) return 0;
+  if (an) return 1;
+  if (bn) return -1;
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  const as = typeof a === "string" ? a : stringifyCell(a);
+  const bs = typeof b === "string" ? b : stringifyCell(b);
+  const an2 = Number(as);
+  const bn2 = Number(bs);
+  if (Number.isFinite(an2) && Number.isFinite(bn2) && as.trim() !== "" && bs.trim() !== "") {
+    return an2 - bn2;
+  }
+  return as.localeCompare(bs, undefined, { numeric: true, sensitivity: "base" });
+};
+
+const VIEW_ITEMS: {
+  id: ResultsViewMode;
+  active: "albums" | "grid" | "code-slash";
+  inactive: "albums-outline" | "grid-outline" | "code-slash-outline";
+  label: string;
+}[] = [
+  { id: "cards", active: "albums", inactive: "albums-outline", label: "Cards" },
+  { id: "table", active: "grid", inactive: "grid-outline", label: "Table" },
+  { id: "json", active: "code-slash", inactive: "code-slash-outline", label: "JSON" },
+];
+
+const ViewSwitcher = memo(function ViewSwitcher({
+  mode,
+  onChange,
+}: {
+  mode: ResultsViewMode;
+  onChange: (mode: ResultsViewMode) => void;
+}) {
+  const tamagui = useTamaguiTheme();
+  return (
+    <XStack
+      backgroundColor="$surfaceMuted"
+      borderRadius={10}
+      padding={3}
+      gap={2}
+      style={{ borderCurve: "continuous" }}
+    >
+      {VIEW_ITEMS.map((item) => {
+        const active = mode === item.id;
+        return (
+          <Pressable key={item.id} onPress={() => onChange(item.id)} hitSlop={4}>
+            <XStack
+              paddingHorizontal={10}
+              paddingVertical={6}
+              borderRadius={8}
+              backgroundColor={active ? "$surface" : "transparent"}
+              alignItems="center"
+              gap={4}
+            >
+              <Ionicons
+                name={active ? item.active : item.inactive}
+                size={13}
+                color={active ? tamagui.color.val : tamagui.placeholderColor.val}
+              />
+              <Text
+                color={active ? "$color" : "$placeholderColor"}
+                fontSize={11}
+                fontWeight="600"
+              >
+                {item.label}
+              </Text>
+            </XStack>
+          </Pressable>
+        );
+      })}
+    </XStack>
+  );
+});
+
+export const ResultsView = memo(function ResultsView({
+  result,
+  connectionId,
+  query,
+  onCopyAll,
+}: ResultsViewProps) {
+  const tamagui = useTamaguiTheme();
+  const haptic = useHaptic();
+  const [mode, setMode] = useState<ResultsViewMode>("cards");
+  const [search, setSearch] = useState("");
+  const [sortColumn, setSortColumn] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>(null);
+  const [prefs, setPrefs] = useState<ColumnPrefs>({ pinned: [], hidden: [] });
+  const [showCustomize, setShowCustomize] = useState(false);
+  const [showSort, setShowSort] = useState(false);
+  const [detailRow, setDetailRow] = useState<Record<string, unknown> | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+
+  const prefsKey = useMemo(() => buildPrefsKey(connectionId, query), [connectionId, query]);
+
+  // Load mode preference for this connection.
+  useEffect(() => {
+    let cancelled = false;
+    getResultsViewMode(connectionId).then((m) => {
+      if (!cancelled && m) setMode(m);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [connectionId]);
+
+  // Load column prefs for this (connection, query) pair.
+  useEffect(() => {
+    let cancelled = false;
+    getColumnPrefs(prefsKey).then((p) => {
+      if (!cancelled) setPrefs(p);
+    });
+    setSortColumn(null);
+    setSortDir(null);
+    setSearch("");
+    return () => {
+      cancelled = true;
+    };
+  }, [prefsKey]);
+
+  const handleModeChange = useCallback(
+    (next: ResultsViewMode) => {
+      setMode(next);
+      haptic.light();
+      setResultsViewMode(connectionId, next).catch(() => {});
+    },
+    [connectionId, haptic],
+  );
+
+  const handlePrefsChange = useCallback(
+    (next: ColumnPrefs) => {
+      setPrefs(next);
+      setColumnPrefs(prefsKey, next).catch(() => {});
+    },
+    [prefsKey],
+  );
+
+  const handlePrefsReset = useCallback(() => {
+    handlePrefsChange({ pinned: [], hidden: [] });
+  }, [handlePrefsChange]);
+
+  const resolved = useMemo(
+    () => resolveColumns(result.columns, result.rows, prefs.pinned, prefs.hidden, 3),
+    [result.columns, result.rows, prefs.pinned, prefs.hidden],
+  );
+
+  const filteredRows = useMemo(() => {
+    if (!search.trim()) return result.rows;
+    const needle = search.trim().toLowerCase();
+    const cols = resolved.visible;
+    return result.rows.filter((row) => {
+      for (const col of cols) {
+        if (cellSearchString(row[col.name]).includes(needle)) return true;
+      }
+      return false;
+    });
+  }, [search, result.rows, resolved.visible]);
+
+  const displayRows = useMemo(() => {
+    if (!sortColumn || !sortDir) return filteredRows;
+    const sorted = [...filteredRows].sort((a, b) =>
+      compareValues(a[sortColumn], b[sortColumn]),
+    );
+    if (sortDir === "desc") sorted.reverse();
+    return sorted;
+  }, [filteredRows, sortColumn, sortDir]);
+
+  const handleSortChange = useCallback((col: string, dir: SortDir) => {
+    setSortColumn(dir === null ? null : col);
+    setSortDir(dir);
+  }, []);
+
+  const handleSortClear = useCallback(() => {
+    setSortColumn(null);
+    setSortDir(null);
+    setShowSort(false);
+  }, []);
+
+  const handleSortSelect = useCallback((col: string, dir: SortDir) => {
+    setSortColumn(dir === null ? null : col);
+    setSortDir(dir);
+  }, []);
+
+  const handleOpenDetail = useCallback((row: Record<string, unknown>) => {
+    setDetailRow(row);
+    setDetailOpen(true);
+  }, []);
+
+  const command = result.command.trim().toUpperCase().split(" ")[0] ?? "";
+
+  if (result.columns.length === 0) {
+    return (
+      <XStack
+        alignItems="center"
+        gap="$sm"
+        paddingVertical="$lg"
+        paddingHorizontal="$xs"
+      >
+        <Text color="$success" fontSize={18} fontWeight="600">
+          ✓
+        </Text>
+        <Text color="$textMuted" fontSize={14}>
+          {result.rowCount > 0
+            ? `${result.rowCount.toLocaleString()} row${
+                result.rowCount === 1 ? "" : "s"
+              } affected`
+            : "Query executed successfully"}
+        </Text>
+      </XStack>
+    );
+  }
+
+  return (
+    <YStack flex={1} gap="$sm">
+      <YStack gap="$sm">
+        <XStack alignItems="center" justifyContent="space-between" gap="$sm">
+          <XStack alignItems="baseline" gap={4} flex={1}>
+            <Text color="$color" fontSize={14} fontWeight="600" fontFamily="$mono">
+              {result.rowCount.toLocaleString()}
+            </Text>
+            <Text color="$placeholderColor" fontSize={12}>
+              rows
+            </Text>
+            <Text color="$placeholderColor" fontSize={12}>
+              {" · "}
+            </Text>
+            <Text color="$placeholderColor" fontSize={12} fontFamily="$mono">
+              {result.executionTime}ms
+            </Text>
+            <Text color="$placeholderColor" fontSize={12}>
+              {" · "}
+            </Text>
+            <Text
+              color="$placeholderColor"
+              fontSize={10}
+              fontFamily="$mono"
+              fontWeight="600"
+              letterSpacing={0.4}
+            >
+              {command}
+            </Text>
+          </XStack>
+          <ViewSwitcher mode={mode} onChange={handleModeChange} />
+        </XStack>
+
+        <XStack alignItems="center" gap="$sm">
+          <XStack
+            flex={1}
+            alignItems="center"
+            backgroundColor="$surface"
+            borderRadius="$sm"
+            borderWidth={1}
+            borderColor="$borderColor"
+            paddingHorizontal="$sm"
+            gap={6}
+            height={34}
+          >
+            <Ionicons name="search" size={13} color={tamagui.placeholderColor.val} />
+            <TextInput
+              value={search}
+              onChangeText={setSearch}
+              placeholder="Filter rows…"
+              placeholderTextColor={tamagui.placeholderColor.val}
+              autoCapitalize="none"
+              autoCorrect={false}
+              style={{
+                flex: 1,
+                color: tamagui.color.val,
+                fontSize: 13,
+                paddingVertical: 0,
+              }}
+            />
+            {search ? (
+              <Pressable hitSlop={6} onPress={() => setSearch("")}>
+                <Ionicons
+                  name="close-circle"
+                  size={14}
+                  color={tamagui.placeholderColor.val}
+                />
+              </Pressable>
+            ) : null}
+          </XStack>
+          <Pressable hitSlop={6} onPress={() => setShowSort(true)}>
+            <YStack
+              width={34}
+              height={34}
+              borderRadius={8}
+              backgroundColor={sortColumn ? "$primaryMuted" : "$surfaceMuted"}
+              alignItems="center"
+              justifyContent="center"
+            >
+              <Ionicons
+                name="swap-vertical"
+                size={15}
+                color={sortColumn ? tamagui.primary.val : tamagui.placeholderColor.val}
+              />
+            </YStack>
+          </Pressable>
+          <Pressable hitSlop={6} onPress={() => setShowCustomize(true)}>
+            <YStack
+              width={34}
+              height={34}
+              borderRadius={8}
+              backgroundColor={
+                prefs.pinned.length + prefs.hidden.length > 0 ? "$primaryMuted" : "$surfaceMuted"
+              }
+              alignItems="center"
+              justifyContent="center"
+            >
+              <Ionicons
+                name="options-outline"
+                size={16}
+                color={
+                  prefs.pinned.length + prefs.hidden.length > 0
+                    ? tamagui.primary.val
+                    : tamagui.placeholderColor.val
+                }
+              />
+            </YStack>
+          </Pressable>
+          <Pressable hitSlop={6} onPress={onCopyAll}>
+            <YStack
+              width={34}
+              height={34}
+              borderRadius={8}
+              backgroundColor="$surfaceMuted"
+              alignItems="center"
+              justifyContent="center"
+            >
+              <Ionicons name="copy-outline" size={15} color={tamagui.placeholderColor.val} />
+            </YStack>
+          </Pressable>
+        </XStack>
+      </YStack>
+
+      <YStack flex={1}>
+        {result.rows.length === 0 ? (
+          <YStack
+            flex={1}
+            alignItems="center"
+            justifyContent="center"
+            padding="$lg"
+            gap="$sm"
+          >
+            <Ionicons name="leaf-outline" size={28} color={tamagui.placeholderColor.val} />
+            <Text color="$color" fontSize={15} fontWeight="600">
+              No rows returned
+            </Text>
+            <Text color="$placeholderColor" fontSize={13} textAlign="center">
+              The query ran fine — it just didn't match any rows.
+            </Text>
+          </YStack>
+        ) : mode === "cards" ? (
+          <CardsView rows={displayRows} resolved={resolved} onOpenDetail={handleOpenDetail} />
+        ) : mode === "table" ? (
+          <TableView
+            rows={displayRows}
+            resolved={resolved}
+            sortColumn={sortColumn}
+            sortDir={sortDir}
+            onSortChange={handleSortChange}
+          />
+        ) : (
+          <JsonView rows={displayRows} columns={resolved.visible} />
+        )}
+      </YStack>
+
+      <DetailSheet
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        columns={result.columns}
+        row={detailRow}
+        title={
+          resolved.primary && detailRow
+            ? String(detailRow[resolved.primary.name] ?? "Row details")
+            : "Row details"
+        }
+      />
+
+      <ColumnCustomizeSheet
+        open={showCustomize}
+        onOpenChange={setShowCustomize}
+        columns={result.columns}
+        prefs={prefs}
+        onChange={handlePrefsChange}
+        onReset={handlePrefsReset}
+      />
+
+      <SortSheet
+        open={showSort}
+        onOpenChange={setShowSort}
+        columns={resolved.visible}
+        sortColumn={sortColumn}
+        sortDir={sortDir}
+        onSelect={handleSortSelect}
+        onClear={handleSortClear}
+      />
+    </YStack>
+  );
+});

--- a/apps/mobile/components/results/SortSheet.tsx
+++ b/apps/mobile/components/results/SortSheet.tsx
@@ -112,9 +112,7 @@ export const SortSheet = memo(function SortSheet({
                           }
                         />
                         <Text
-                          color={
-                            isSorted && sortDir === "asc" ? "$primary" : "$placeholderColor"
-                          }
+                          color={isSorted && sortDir === "asc" ? "$primary" : "$placeholderColor"}
                           fontSize={11}
                           fontWeight="600"
                         >
@@ -149,9 +147,7 @@ export const SortSheet = memo(function SortSheet({
                           }
                         />
                         <Text
-                          color={
-                            isSorted && sortDir === "desc" ? "$primary" : "$placeholderColor"
-                          }
+                          color={isSorted && sortDir === "desc" ? "$primary" : "$placeholderColor"}
                           fontSize={11}
                           fontWeight="600"
                         >

--- a/apps/mobile/components/results/SortSheet.tsx
+++ b/apps/mobile/components/results/SortSheet.tsx
@@ -1,0 +1,171 @@
+import { Ionicons } from "@expo/vector-icons";
+import { memo } from "react";
+import { Pressable, ScrollView } from "react-native";
+import { Sheet, Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import type { ColumnInfo } from "../../lib/types";
+
+export type SortDir = "asc" | "desc" | null;
+
+type SortSheetProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  columns: ColumnInfo[];
+  sortColumn: string | null;
+  sortDir: SortDir;
+  onSelect: (column: string, dir: SortDir) => void;
+  onClear: () => void;
+};
+
+export const SortSheet = memo(function SortSheet({
+  open,
+  onOpenChange,
+  columns,
+  sortColumn,
+  sortDir,
+  onSelect,
+  onClear,
+}: SortSheetProps) {
+  const tamagui = useTamaguiTheme();
+
+  return (
+    <Sheet
+      modal
+      open={open}
+      onOpenChange={onOpenChange}
+      animation="medium"
+      zIndex={200000}
+      dismissOnSnapToBottom
+      snapPoints={[70]}
+    >
+      <Sheet.Overlay
+        animation="lazy"
+        enterStyle={{ opacity: 0 }}
+        exitStyle={{ opacity: 0 }}
+        backgroundColor="$dialogOverlay"
+      />
+      <Sheet.Frame
+        backgroundColor="$surfaceElevated"
+        borderTopLeftRadius={20}
+        borderTopRightRadius={20}
+        padding="$lg"
+        gap="$md"
+      >
+        <Sheet.Handle backgroundColor="$dialogHandle" alignSelf="center" />
+        <XStack alignItems="center" justifyContent="space-between">
+          <Text fontSize={17} fontWeight="600" color="$color" letterSpacing={-0.2}>
+            Sort by
+          </Text>
+          <Pressable hitSlop={10} onPress={onClear}>
+            <Text color="$primary" fontSize={13} fontWeight="600">
+              Clear
+            </Text>
+          </Pressable>
+        </XStack>
+
+        <ScrollView showsVerticalScrollIndicator={false}>
+          <YStack gap={6} paddingBottom={32}>
+            {columns.map((col) => {
+              const isSorted = sortColumn === col.name;
+              return (
+                <XStack
+                  key={col.name}
+                  alignItems="center"
+                  justifyContent="space-between"
+                  paddingHorizontal="$sm"
+                  paddingVertical="$sm"
+                  backgroundColor="$surface"
+                  borderRadius="$sm"
+                  borderWidth={1}
+                  borderColor={isSorted ? "$primary" : "$borderColor"}
+                  gap="$sm"
+                >
+                  <YStack flex={1}>
+                    <Text color="$color" fontSize={14} fontWeight="500" numberOfLines={1}>
+                      {col.name}
+                    </Text>
+                  </YStack>
+                  <XStack gap={6}>
+                    <Pressable
+                      hitSlop={6}
+                      onPress={() =>
+                        onSelect(col.name, isSorted && sortDir === "asc" ? null : "asc")
+                      }
+                    >
+                      <XStack
+                        width={64}
+                        height={32}
+                        borderRadius={8}
+                        backgroundColor={
+                          isSorted && sortDir === "asc" ? "$primaryMuted" : "$surfaceMuted"
+                        }
+                        alignItems="center"
+                        justifyContent="center"
+                        gap={4}
+                      >
+                        <Ionicons
+                          name="arrow-up"
+                          size={12}
+                          color={
+                            isSorted && sortDir === "asc"
+                              ? tamagui.primary.val
+                              : tamagui.placeholderColor.val
+                          }
+                        />
+                        <Text
+                          color={
+                            isSorted && sortDir === "asc" ? "$primary" : "$placeholderColor"
+                          }
+                          fontSize={11}
+                          fontWeight="600"
+                        >
+                          ASC
+                        </Text>
+                      </XStack>
+                    </Pressable>
+                    <Pressable
+                      hitSlop={6}
+                      onPress={() =>
+                        onSelect(col.name, isSorted && sortDir === "desc" ? null : "desc")
+                      }
+                    >
+                      <XStack
+                        width={64}
+                        height={32}
+                        borderRadius={8}
+                        backgroundColor={
+                          isSorted && sortDir === "desc" ? "$primaryMuted" : "$surfaceMuted"
+                        }
+                        alignItems="center"
+                        justifyContent="center"
+                        gap={4}
+                      >
+                        <Ionicons
+                          name="arrow-down"
+                          size={12}
+                          color={
+                            isSorted && sortDir === "desc"
+                              ? tamagui.primary.val
+                              : tamagui.placeholderColor.val
+                          }
+                        />
+                        <Text
+                          color={
+                            isSorted && sortDir === "desc" ? "$primary" : "$placeholderColor"
+                          }
+                          fontSize={11}
+                          fontWeight="600"
+                        >
+                          DESC
+                        </Text>
+                      </XStack>
+                    </Pressable>
+                  </XStack>
+                </XStack>
+              );
+            })}
+          </YStack>
+        </ScrollView>
+      </Sheet.Frame>
+    </Sheet>
+  );
+});

--- a/apps/mobile/components/results/TableView.tsx
+++ b/apps/mobile/components/results/TableView.tsx
@@ -36,11 +36,8 @@ const computeColumnWidth = (col: ColumnInfo, rows: Record<string, unknown>[]): n
   const headerPx = Math.max(col.name.length, (col.type ?? "").length) * COL_CHAR_PX + COL_PAD;
   const maxContent = rows.slice(0, 40).reduce((mx, row) => {
     const v = row[col.name];
-    const s = v === null || v === undefined
-      ? ""
-      : typeof v === "object"
-        ? JSON.stringify(v)
-        : String(v);
+    const s =
+      v === null || v === undefined ? "" : typeof v === "object" ? JSON.stringify(v) : String(v);
     return Math.max(mx, Math.min(s.length, 36));
   }, 0);
   const contentPx = maxContent * COL_CHAR_PX + COL_PAD;
@@ -149,13 +146,7 @@ const HeaderCell = memo(function HeaderCell({
         borderRightColor="$borderColor"
       >
         <YStack flex={1} gap={2}>
-          <Text
-            color="$color"
-            fontSize={12}
-            fontWeight="600"
-            fontFamily="$mono"
-            numberOfLines={1}
-          >
+          <Text color="$color" fontSize={12} fontWeight="600" fontFamily="$mono" numberOfLines={1}>
             {column.name}
           </Text>
           {column.type ? (
@@ -165,9 +156,7 @@ const HeaderCell = memo(function HeaderCell({
           ) : null}
         </YStack>
         <SortIndicator dir={isSorted ? sortDir : null} />
-        {resizing ? (
-          <ResizeHandle onChange={onResizeChange} onCommit={onResizeCommit} />
-        ) : null}
+        {resizing ? <ResizeHandle onChange={onResizeChange} onCommit={onResizeCommit} /> : null}
       </XStack>
     </Pressable>
   );

--- a/apps/mobile/components/results/TableView.tsx
+++ b/apps/mobile/components/results/TableView.tsx
@@ -2,6 +2,7 @@ import { Ionicons } from "@expo/vector-icons";
 import * as Clipboard from "expo-clipboard";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  FlatList,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
   PanResponder,
@@ -172,6 +173,38 @@ const HeaderCell = memo(function HeaderCell({
   );
 });
 
+const DataRow = memo(function DataRow({
+  row,
+  index,
+  stickyWidth,
+  dataCols,
+  widths,
+  onCopy,
+}: {
+  row: Record<string, unknown>;
+  index: number;
+  stickyWidth: number;
+  dataCols: ColumnInfo[];
+  widths: Record<string, number>;
+  onCopy: (v: unknown) => void;
+}) {
+  return (
+    <XStack>
+      {stickyWidth > 0 ? <YStack width={stickyWidth} /> : null}
+      {dataCols.map((col) => (
+        <DataCell
+          key={`c-${col.name}`}
+          column={col}
+          value={row[col.name]}
+          width={widths[col.name] ?? COL_MIN}
+          alt={index % 2 === 1}
+          onCopy={onCopy}
+        />
+      ))}
+    </XStack>
+  );
+});
+
 const DataCell = memo(function DataCell({
   column,
   value,
@@ -310,15 +343,15 @@ export const TableView = memo(function TableView({
     [resizingCol, handleSortPress],
   );
 
-  const verticalScrollRef = useRef<ScrollView>(null);
-  const stickyScrollRef = useRef<ScrollView>(null);
+  const verticalScrollRef = useRef<FlatList<Record<string, unknown>>>(null);
+  const stickyScrollRef = useRef<FlatList<Record<string, unknown>>>(null);
   const lastSyncedRef = useRef(0);
 
   const onMainScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
     const y = e.nativeEvent.contentOffset.y;
     if (Math.abs(y - lastSyncedRef.current) < 0.5) return;
     lastSyncedRef.current = y;
-    stickyScrollRef.current?.scrollTo({ y, animated: false });
+    stickyScrollRef.current?.scrollToOffset({ offset: y, animated: false });
   }, []);
 
   const renderHeader = (col: ColumnInfo, width: number, isSticky: boolean) => (
@@ -363,34 +396,36 @@ export const TableView = memo(function TableView({
           bounces={false}
           contentContainerStyle={{ minWidth: totalDataWidth + (stickyCol ? PK_WIDTH : 0) }}
         >
-          <ScrollView
+          <FlatList
             ref={verticalScrollRef}
+            data={rows}
+            keyExtractor={(_, i) => `r-${i}`}
             scrollEventThrottle={16}
             onScroll={onMainScroll}
             showsVerticalScrollIndicator={false}
             stickyHeaderIndices={[0]}
             nestedScrollEnabled
-          >
-            <XStack backgroundColor="$surfaceAlt">
-              {stickyCol ? <YStack width={PK_WIDTH} /> : null}
-              {dataCols.map((col) => renderHeader(col, widths[col.name] ?? COL_MIN, false))}
-            </XStack>
-            {rows.map((row, ri) => (
-              <XStack key={`r-${ri}`}>
+            removeClippedSubviews
+            initialNumToRender={20}
+            windowSize={9}
+            maxToRenderPerBatch={20}
+            ListHeaderComponent={
+              <XStack backgroundColor="$surfaceAlt">
                 {stickyCol ? <YStack width={PK_WIDTH} /> : null}
-                {dataCols.map((col) => (
-                  <DataCell
-                    key={`c-${col.name}-${ri}`}
-                    column={col}
-                    value={row[col.name]}
-                    width={widths[col.name] ?? COL_MIN}
-                    alt={ri % 2 === 1}
-                    onCopy={copyCell}
-                  />
-                ))}
+                {dataCols.map((col) => renderHeader(col, widths[col.name] ?? COL_MIN, false))}
               </XStack>
-            ))}
-          </ScrollView>
+            }
+            renderItem={({ item, index }) => (
+              <DataRow
+                row={item}
+                index={index}
+                stickyWidth={stickyCol ? PK_WIDTH : 0}
+                dataCols={dataCols}
+                widths={widths}
+                onCopy={copyCell}
+              />
+            )}
+          />
         </ScrollView>
 
         {stickyCol ? (
@@ -404,26 +439,32 @@ export const TableView = memo(function TableView({
             }}
             pointerEvents="box-none"
           >
-            <ScrollView
+            <FlatList
               ref={stickyScrollRef}
+              data={rows}
+              keyExtractor={(_, i) => `sticky-${i}`}
               showsVerticalScrollIndicator={false}
               scrollEnabled={false}
               stickyHeaderIndices={[0]}
-            >
-              <XStack backgroundColor="$surfaceAlt">
-                {renderHeader(stickyCol, PK_WIDTH, true)}
-              </XStack>
-              {rows.map((row, ri) => (
+              removeClippedSubviews
+              initialNumToRender={20}
+              windowSize={9}
+              maxToRenderPerBatch={20}
+              ListHeaderComponent={
+                <XStack backgroundColor="$surfaceAlt">
+                  {renderHeader(stickyCol, PK_WIDTH, true)}
+                </XStack>
+              }
+              renderItem={({ item, index }) => (
                 <DataCell
-                  key={`sticky-${ri}`}
                   column={stickyCol}
-                  value={row[stickyCol.name]}
+                  value={item[stickyCol.name]}
                   width={PK_WIDTH}
-                  alt={ri % 2 === 1}
+                  alt={index % 2 === 1}
                   onCopy={copyCell}
                 />
-              ))}
-            </ScrollView>
+              )}
+            />
           </View>
         ) : null}
       </View>

--- a/apps/mobile/components/results/TableView.tsx
+++ b/apps/mobile/components/results/TableView.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import * as Clipboard from "expo-clipboard";
-import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type NativeScrollEvent,
   type NativeSyntheticEvent,
@@ -230,6 +230,18 @@ export const TableView = memo(function TableView({
     () => resolved.visible.filter((c) => c.name !== stickyCol?.name),
     [resolved.visible, stickyCol],
   );
+
+  // Reset user-resized widths when the column set changes — e.g. when the
+  // user runs a new query whose columns happen to overlap with the previous
+  // result. Without this, the prior widths leak across unrelated queries.
+  const columnsSignature = useMemo(
+    () => resolved.visible.map((c) => c.name).join("|"),
+    [resolved.visible],
+  );
+  useEffect(() => {
+    setWidthOverrides({});
+    setResizingCol(null);
+  }, [columnsSignature]);
 
   const widths = useMemo(() => {
     const map: Record<string, number> = {};

--- a/apps/mobile/components/results/TableView.tsx
+++ b/apps/mobile/components/results/TableView.tsx
@@ -1,0 +1,420 @@
+import { Ionicons } from "@expo/vector-icons";
+import * as Clipboard from "expo-clipboard";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import {
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  PanResponder,
+  Pressable,
+  ScrollView,
+  View,
+} from "react-native";
+import { Text, useTheme as useTamaguiTheme, XStack, YStack } from "tamagui";
+import { useHaptic } from "../../lib/haptics";
+import type { ColumnInfo } from "../../lib/types";
+import type { ResolvedColumns } from "./columnPriority";
+import { previewString, stringifyCell } from "./format";
+
+type SortDir = "asc" | "desc" | null;
+
+type TableViewProps = {
+  rows: Record<string, unknown>[];
+  resolved: ResolvedColumns;
+  sortColumn: string | null;
+  sortDir: SortDir;
+  onSortChange: (column: string, dir: SortDir) => void;
+};
+
+const COL_CHAR_PX = 8.2;
+const COL_PAD = 28;
+const COL_MIN = 80;
+const COL_MAX = 240;
+const PK_WIDTH = 132;
+
+const computeColumnWidth = (col: ColumnInfo, rows: Record<string, unknown>[]): number => {
+  const headerPx = Math.max(col.name.length, (col.type ?? "").length) * COL_CHAR_PX + COL_PAD;
+  const maxContent = rows.slice(0, 40).reduce((mx, row) => {
+    const v = row[col.name];
+    const s = v === null || v === undefined
+      ? ""
+      : typeof v === "object"
+        ? JSON.stringify(v)
+        : String(v);
+    return Math.max(mx, Math.min(s.length, 36));
+  }, 0);
+  const contentPx = maxContent * COL_CHAR_PX + COL_PAD;
+  return Math.min(Math.max(Math.max(headerPx, contentPx), COL_MIN), COL_MAX);
+};
+
+const SortIndicator = ({ dir }: { dir: SortDir }) => {
+  const tamagui = useTamaguiTheme();
+  const muted = tamagui.placeholderColor.val;
+  const active = tamagui.primary.val;
+  return (
+    <YStack alignItems="center" justifyContent="center">
+      <Ionicons name="caret-up" size={9} color={dir === "asc" ? active : muted} />
+      <YStack marginTop={-2}>
+        <Ionicons name="caret-down" size={9} color={dir === "desc" ? active : muted} />
+      </YStack>
+    </YStack>
+  );
+};
+
+const ResizeHandle = ({
+  onChange,
+  onCommit,
+}: {
+  onChange: (delta: number) => void;
+  onCommit: () => void;
+}) => {
+  const startedRef = useRef(0);
+  const responder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+        onPanResponderGrant: () => {
+          startedRef.current = 0;
+        },
+        onPanResponderMove: (_, gs) => {
+          onChange(gs.dx - startedRef.current);
+          startedRef.current = gs.dx;
+        },
+        onPanResponderRelease: () => {
+          onCommit();
+        },
+        onPanResponderTerminate: () => {
+          onCommit();
+        },
+      }),
+    [onChange, onCommit],
+  );
+  return (
+    <View
+      {...responder.panHandlers}
+      style={{
+        position: "absolute",
+        right: 0,
+        top: 0,
+        bottom: 0,
+        width: 18,
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <View
+        style={{
+          width: 3,
+          height: 22,
+          borderRadius: 2,
+          backgroundColor: "rgba(124,92,255,0.85)",
+        }}
+      />
+    </View>
+  );
+};
+
+const HeaderCell = memo(function HeaderCell({
+  column,
+  width,
+  isSorted,
+  sortDir,
+  onPress,
+  onLongPress,
+  resizing,
+  onResizeChange,
+  onResizeCommit,
+}: {
+  column: ColumnInfo;
+  width: number;
+  isSorted: boolean;
+  sortDir: SortDir;
+  onPress: () => void;
+  onLongPress: () => void;
+  resizing: boolean;
+  onResizeChange: (delta: number) => void;
+  onResizeCommit: () => void;
+}) {
+  return (
+    <Pressable onPress={onPress} onLongPress={onLongPress} delayLongPress={350}>
+      <XStack
+        width={width}
+        paddingHorizontal="$sm"
+        paddingVertical={9}
+        alignItems="center"
+        gap={6}
+        backgroundColor={resizing ? "$primaryMuted" : "$surfaceAlt"}
+        borderRightWidth={1}
+        borderRightColor="$borderColor"
+      >
+        <YStack flex={1} gap={2}>
+          <Text
+            color="$color"
+            fontSize={12}
+            fontWeight="600"
+            fontFamily="$mono"
+            numberOfLines={1}
+          >
+            {column.name}
+          </Text>
+          {column.type ? (
+            <Text color="$placeholderColor" fontSize={10} fontFamily="$mono" numberOfLines={1}>
+              {column.type.toLowerCase()}
+            </Text>
+          ) : null}
+        </YStack>
+        <SortIndicator dir={isSorted ? sortDir : null} />
+        {resizing ? (
+          <ResizeHandle onChange={onResizeChange} onCommit={onResizeCommit} />
+        ) : null}
+      </XStack>
+    </Pressable>
+  );
+});
+
+const DataCell = memo(function DataCell({
+  column,
+  value,
+  width,
+  alt,
+  onCopy,
+}: {
+  column: ColumnInfo;
+  value: unknown;
+  width: number;
+  alt: boolean;
+  onCopy: (v: unknown) => void;
+}) {
+  return (
+    <Pressable onPress={() => onCopy(value)}>
+      <XStack
+        width={width}
+        paddingHorizontal="$sm"
+        paddingVertical={10}
+        backgroundColor={alt ? "$surfaceAlt" : "$surface"}
+        borderRightWidth={1}
+        borderRightColor="$borderColor"
+        borderBottomWidth={1}
+        borderBottomColor="$borderColor"
+        alignItems="flex-start"
+      >
+        {value === null || value === undefined ? (
+          <Text color="$placeholderColor" fontSize={12} fontFamily="$mono" fontStyle="italic">
+            null
+          </Text>
+        ) : (
+          <Text color="$textMuted" fontSize={13} fontFamily="$mono" numberOfLines={3}>
+            {typeof value === "object"
+              ? previewString(stringifyCell(value), 200)
+              : previewString(String(value), 200)}
+          </Text>
+        )}
+      </XStack>
+    </Pressable>
+  );
+});
+
+export const TableView = memo(function TableView({
+  rows,
+  resolved,
+  sortColumn,
+  sortDir,
+  onSortChange,
+}: TableViewProps) {
+  const haptic = useHaptic();
+  const [widthOverrides, setWidthOverrides] = useState<Record<string, number>>({});
+  const [resizingCol, setResizingCol] = useState<string | null>(null);
+
+  const stickyCol = resolved.primary;
+  const dataCols = useMemo(
+    () => resolved.visible.filter((c) => c.name !== stickyCol?.name),
+    [resolved.visible, stickyCol],
+  );
+
+  const widths = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const col of dataCols) {
+      map[col.name] = widthOverrides[col.name] ?? computeColumnWidth(col, rows);
+    }
+    return map;
+  }, [dataCols, rows, widthOverrides]);
+
+  const totalDataWidth = useMemo(
+    () => dataCols.reduce((sum, c) => sum + (widths[c.name] ?? COL_MIN), 0),
+    [dataCols, widths],
+  );
+
+  const handleSortPress = useCallback(
+    (col: string) => {
+      if (sortColumn !== col) {
+        onSortChange(col, "asc");
+        return;
+      }
+      const next: SortDir = sortDir === "asc" ? "desc" : sortDir === "desc" ? null : "asc";
+      onSortChange(col, next);
+    },
+    [sortColumn, sortDir, onSortChange],
+  );
+
+  const onLongPressHeader = useCallback(
+    (col: string) => {
+      haptic.medium();
+      setResizingCol((cur) => (cur === col ? null : col));
+    },
+    [haptic],
+  );
+
+  const handleResizeChange = useCallback(
+    (col: string, delta: number) => {
+      setWidthOverrides((prev) => {
+        const current = prev[col] ?? widths[col] ?? COL_MIN;
+        const next = Math.max(COL_MIN, Math.min(COL_MAX * 1.5, current + delta));
+        return { ...prev, [col]: next };
+      });
+    },
+    [widths],
+  );
+
+  const handleResizeCommit = useCallback(() => {
+    setResizingCol(null);
+  }, []);
+
+  const copyCell = useCallback(
+    async (v: unknown) => {
+      await Clipboard.setStringAsync(stringifyCell(v));
+      haptic.light();
+    },
+    [haptic],
+  );
+
+  const handleHeaderTap = useCallback(
+    (col: string) => {
+      if (resizingCol) {
+        setResizingCol(null);
+        return;
+      }
+      handleSortPress(col);
+    },
+    [resizingCol, handleSortPress],
+  );
+
+  const verticalScrollRef = useRef<ScrollView>(null);
+  const stickyScrollRef = useRef<ScrollView>(null);
+  const lastSyncedRef = useRef(0);
+
+  const onMainScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const y = e.nativeEvent.contentOffset.y;
+    if (Math.abs(y - lastSyncedRef.current) < 0.5) return;
+    lastSyncedRef.current = y;
+    stickyScrollRef.current?.scrollTo({ y, animated: false });
+  }, []);
+
+  const renderHeader = (col: ColumnInfo, width: number, isSticky: boolean) => (
+    <HeaderCell
+      key={`h-${col.name}`}
+      column={col}
+      width={width}
+      isSorted={sortColumn === col.name}
+      sortDir={sortDir}
+      onPress={() => handleHeaderTap(col.name)}
+      onLongPress={isSticky ? () => {} : () => onLongPressHeader(col.name)}
+      resizing={resizingCol === col.name}
+      onResizeChange={(d) => handleResizeChange(col.name, d)}
+      onResizeCommit={handleResizeCommit}
+    />
+  );
+
+  if (rows.length === 0) {
+    return (
+      <YStack flex={1} alignItems="center" justifyContent="center" padding="$lg" gap="$sm">
+        <Ionicons name="grid-outline" size={28} color="#8a8aa0" />
+        <Text color="$placeholderColor" fontSize={14}>
+          No rows match the current view.
+        </Text>
+      </YStack>
+    );
+  }
+
+  return (
+    <YStack
+      flex={1}
+      borderRadius="$md"
+      borderWidth={1}
+      borderColor="$borderColor"
+      overflow="hidden"
+      style={{ borderCurve: "continuous" }}
+    >
+      <View style={{ flex: 1, position: "relative" }}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          bounces={false}
+          contentContainerStyle={{ minWidth: totalDataWidth + (stickyCol ? PK_WIDTH : 0) }}
+        >
+          <ScrollView
+            ref={verticalScrollRef}
+            scrollEventThrottle={16}
+            onScroll={onMainScroll}
+            showsVerticalScrollIndicator={false}
+            stickyHeaderIndices={[0]}
+            nestedScrollEnabled
+          >
+            <XStack backgroundColor="$surfaceAlt">
+              {stickyCol ? <YStack width={PK_WIDTH} /> : null}
+              {dataCols.map((col) => renderHeader(col, widths[col.name] ?? COL_MIN, false))}
+            </XStack>
+            {rows.map((row, ri) => (
+              <XStack key={`r-${ri}`}>
+                {stickyCol ? <YStack width={PK_WIDTH} /> : null}
+                {dataCols.map((col) => (
+                  <DataCell
+                    key={`c-${col.name}-${ri}`}
+                    column={col}
+                    value={row[col.name]}
+                    width={widths[col.name] ?? COL_MIN}
+                    alt={ri % 2 === 1}
+                    onCopy={copyCell}
+                  />
+                ))}
+              </XStack>
+            ))}
+          </ScrollView>
+        </ScrollView>
+
+        {stickyCol ? (
+          <View
+            style={{
+              position: "absolute",
+              left: 0,
+              top: 0,
+              bottom: 0,
+              width: PK_WIDTH,
+            }}
+            pointerEvents="box-none"
+          >
+            <ScrollView
+              ref={stickyScrollRef}
+              showsVerticalScrollIndicator={false}
+              scrollEnabled={false}
+              stickyHeaderIndices={[0]}
+            >
+              <XStack backgroundColor="$surfaceAlt">
+                {renderHeader(stickyCol, PK_WIDTH, true)}
+              </XStack>
+              {rows.map((row, ri) => (
+                <DataCell
+                  key={`sticky-${ri}`}
+                  column={stickyCol}
+                  value={row[stickyCol.name]}
+                  width={PK_WIDTH}
+                  alt={ri % 2 === 1}
+                  onCopy={copyCell}
+                />
+              ))}
+            </ScrollView>
+          </View>
+        ) : null}
+      </View>
+    </YStack>
+  );
+});

--- a/apps/mobile/components/results/columnPriority.ts
+++ b/apps/mobile/components/results/columnPriority.ts
@@ -48,10 +48,7 @@ const firstNonNull = (col: string, rows: Row[]): unknown => {
   return null;
 };
 
-export const detectPrimaryKey = (
-  columns: ColumnInfo[],
-  rows: Row[],
-): ColumnInfo | null => {
+export const detectPrimaryKey = (columns: ColumnInfo[], rows: Row[]): ColumnInfo | null => {
   if (columns.length === 0) return null;
   const exact = columns.find((c) => isLikelyPkName(c.name));
   if (exact) return exact;
@@ -93,10 +90,7 @@ export interface OrderedColumns {
   ordered: ColumnInfo[];
 }
 
-export const orderColumnsByPriority = (
-  columns: ColumnInfo[],
-  rows: Row[],
-): OrderedColumns => {
+export const orderColumnsByPriority = (columns: ColumnInfo[], rows: Row[]): OrderedColumns => {
   const primary = detectPrimaryKey(columns, rows);
   const pkName = primary?.name ?? null;
   const ordered = [...columns]

--- a/apps/mobile/components/results/columnPriority.ts
+++ b/apps/mobile/components/results/columnPriority.ts
@@ -1,0 +1,151 @@
+import type { ColumnInfo } from "../../lib/types";
+import {
+  isBooleanType,
+  isDateType,
+  isJsonType,
+  isNullish,
+  isNumericType,
+  isTextType,
+} from "./format";
+
+type Row = Record<string, unknown>;
+
+const SHORT_STRING_MAX = 32;
+
+const isLikelyPkName = (name: string): boolean => {
+  const n = name.toLowerCase();
+  if (n === "_id" || n === "id" || n === "uuid") return true;
+  return false;
+};
+
+const isPkSuffix = (name: string): boolean => name.toLowerCase().endsWith("_id");
+
+const sampleStringLength = (col: string, rows: Row[]): number => {
+  let max = 0;
+  for (let i = 0; i < Math.min(rows.length, 25); i++) {
+    const v = rows[i]?.[col];
+    if (typeof v === "string") max = Math.max(max, v.length);
+    else if (!isNullish(v)) max = Math.max(max, String(v).length);
+  }
+  return max;
+};
+
+const isShortStringColumn = (col: ColumnInfo, rows: Row[]): boolean => {
+  if (!isTextType(col.type)) return false;
+  const len = sampleStringLength(col.name, rows);
+  return len > 0 && len <= SHORT_STRING_MAX;
+};
+
+const isLongTextColumn = (col: ColumnInfo, rows: Row[]): boolean => {
+  if (!isTextType(col.type)) return false;
+  return sampleStringLength(col.name, rows) > SHORT_STRING_MAX;
+};
+
+const firstNonNull = (col: string, rows: Row[]): unknown => {
+  for (const row of rows) {
+    if (!isNullish(row[col])) return row[col];
+  }
+  return null;
+};
+
+export const detectPrimaryKey = (
+  columns: ColumnInfo[],
+  rows: Row[],
+): ColumnInfo | null => {
+  if (columns.length === 0) return null;
+  const exact = columns.find((c) => isLikelyPkName(c.name));
+  if (exact) return exact;
+  const suffix = columns.find((c) => isPkSuffix(c.name));
+  if (suffix) return suffix;
+  // Fall back to first non-null short-string-ish column
+  for (const col of columns) {
+    const v = firstNonNull(col.name, rows);
+    if (!isNullish(v)) {
+      const s = typeof v === "string" ? v : String(v);
+      if (s.length <= SHORT_STRING_MAX) return col;
+    }
+  }
+  return columns[0] ?? null;
+};
+
+type Tier = 1 | 2 | 3 | 4 | 5;
+
+const columnTier = (col: ColumnInfo, rows: Row[], pkName: string | null): Tier => {
+  if (pkName && col.name === pkName) return 1;
+  if (isLongTextColumn(col, rows) || isJsonType(col.type)) return 5;
+  if (isShortStringColumn(col, rows)) return 2;
+  if (isNumericType(col.type)) return 3;
+  if (isDateType(col.type)) return 3;
+  if (isBooleanType(col.type)) return 4;
+  // Unknown: peek at sample
+  const v = firstNonNull(col.name, rows);
+  if (typeof v === "string") {
+    return v.length <= SHORT_STRING_MAX ? 2 : 5;
+  }
+  if (typeof v === "number") return 3;
+  if (typeof v === "boolean") return 4;
+  if (typeof v === "object" && v !== null) return 5;
+  return 4;
+};
+
+export interface OrderedColumns {
+  primary: ColumnInfo | null;
+  ordered: ColumnInfo[];
+}
+
+export const orderColumnsByPriority = (
+  columns: ColumnInfo[],
+  rows: Row[],
+): OrderedColumns => {
+  const primary = detectPrimaryKey(columns, rows);
+  const pkName = primary?.name ?? null;
+  const ordered = [...columns]
+    .map((c, i) => ({ c, i, tier: columnTier(c, rows, pkName) }))
+    .sort((a, b) => a.tier - b.tier || a.i - b.i)
+    .map((entry) => entry.c);
+  return { primary, ordered };
+};
+
+export interface ResolvedColumns {
+  primary: ColumnInfo | null;
+  visible: ColumnInfo[];
+  hidden: ColumnInfo[];
+  preview: ColumnInfo[];
+  rest: ColumnInfo[];
+}
+
+export const resolveColumns = (
+  columns: ColumnInfo[],
+  rows: Row[],
+  pinned: string[],
+  hidden: string[],
+  previewCount = 3,
+): ResolvedColumns => {
+  const { primary, ordered } = orderColumnsByPriority(columns, rows);
+  const hiddenSet = new Set(hidden);
+  const pinnedSet = new Set(pinned);
+
+  const visible = ordered.filter((c) => !hiddenSet.has(c.name));
+  const hiddenCols = ordered.filter((c) => hiddenSet.has(c.name));
+
+  const pinnedFirst: ColumnInfo[] = [];
+  const others: ColumnInfo[] = [];
+  for (const col of visible) {
+    if (pinnedSet.has(col.name)) pinnedFirst.push(col);
+    else others.push(col);
+  }
+  const finalVisible = [...pinnedFirst, ...others];
+
+  // Preview = primary chip column + next N visible columns (excluding primary).
+  const previewExcludingPk = finalVisible.filter((c) => c.name !== primary?.name);
+  const preview = previewExcludingPk.slice(0, previewCount);
+  const rest = previewExcludingPk.slice(previewCount);
+
+  return {
+    primary,
+    visible: finalVisible,
+    hidden: hiddenCols,
+    preview,
+    rest,
+  };
+};

--- a/apps/mobile/components/results/format.ts
+++ b/apps/mobile/components/results/format.ts
@@ -1,12 +1,6 @@
 import type { ColumnInfo } from "../../lib/types";
 
-export type CellKind =
-  | "null"
-  | "boolean"
-  | "number"
-  | "date"
-  | "json"
-  | "string";
+export type CellKind = "null" | "boolean" | "number" | "date" | "json" | "string";
 
 export const isNullish = (v: unknown): v is null | undefined => v === null || v === undefined;
 

--- a/apps/mobile/components/results/format.ts
+++ b/apps/mobile/components/results/format.ts
@@ -1,0 +1,171 @@
+import type { ColumnInfo } from "../../lib/types";
+
+export type CellKind =
+  | "null"
+  | "boolean"
+  | "number"
+  | "date"
+  | "json"
+  | "string";
+
+export const isNullish = (v: unknown): v is null | undefined => v === null || v === undefined;
+
+const NUMERIC_TYPES = new Set([
+  "int",
+  "int2",
+  "int4",
+  "int8",
+  "smallint",
+  "integer",
+  "bigint",
+  "tinyint",
+  "mediumint",
+  "decimal",
+  "numeric",
+  "real",
+  "double",
+  "double precision",
+  "float",
+  "float4",
+  "float8",
+  "money",
+  "serial",
+  "bigserial",
+  "smallserial",
+  "number",
+]);
+
+const BOOLEAN_TYPES = new Set(["bool", "boolean", "tinyint(1)", "bit"]);
+
+const DATE_TYPES = new Set([
+  "date",
+  "datetime",
+  "timestamp",
+  "timestamptz",
+  "timestamp with time zone",
+  "timestamp without time zone",
+  "time",
+  "timetz",
+]);
+
+const JSON_TYPES = new Set(["json", "jsonb", "object", "array"]);
+
+const TEXT_TYPES = new Set([
+  "text",
+  "varchar",
+  "char",
+  "character",
+  "character varying",
+  "string",
+  "uuid",
+  "citext",
+  "name",
+]);
+
+const normalizeType = (type: string | undefined): string =>
+  (type ?? "").toLowerCase().trim().split("(")[0];
+
+export const isBooleanType = (type: string | undefined): boolean =>
+  BOOLEAN_TYPES.has((type ?? "").toLowerCase().trim());
+
+export const isNumericType = (type: string | undefined): boolean =>
+  NUMERIC_TYPES.has(normalizeType(type));
+
+export const isDateType = (type: string | undefined): boolean =>
+  DATE_TYPES.has(normalizeType(type));
+
+export const isJsonType = (type: string | undefined): boolean =>
+  JSON_TYPES.has(normalizeType(type));
+
+export const isTextType = (type: string | undefined): boolean =>
+  TEXT_TYPES.has(normalizeType(type));
+
+export const cellKind = (col: ColumnInfo, value: unknown): CellKind => {
+  if (isNullish(value)) return "null";
+  if (typeof value === "boolean" || isBooleanType(col.type)) return "boolean";
+  if (typeof value === "object") return "json";
+  if (isJsonType(col.type)) return "json";
+  if (isDateType(col.type)) return "date";
+  if (typeof value === "number" || isNumericType(col.type)) return "number";
+  return "string";
+};
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+const tryParseDate = (raw: unknown): Date | null => {
+  if (raw instanceof Date) return Number.isFinite(raw.getTime()) ? raw : null;
+  if (typeof raw === "number") {
+    const d = new Date(raw);
+    return Number.isFinite(d.getTime()) ? d : null;
+  }
+  if (typeof raw !== "string") return null;
+  const d = new Date(raw);
+  return Number.isFinite(d.getTime()) ? d : null;
+};
+
+export const formatDate = (raw: unknown): string => {
+  const d = tryParseDate(raw);
+  if (!d) return String(raw ?? "");
+  const now = new Date();
+  const month = MONTHS[d.getMonth()];
+  const day = d.getDate();
+  if (d.getFullYear() === now.getFullYear()) {
+    return `${month} ${day}`;
+  }
+  return `${month} ${day}, ${String(d.getFullYear()).slice(-2)}`;
+};
+
+export const formatNumberCompact = (n: number): string => {
+  if (!Number.isFinite(n)) return String(n);
+  const abs = Math.abs(n);
+  if (abs >= 1e9) return `${(n / 1e9).toFixed(abs >= 1e10 ? 0 : 1)}B`;
+  if (abs >= 1e6) return `${(n / 1e6).toFixed(abs >= 1e7 ? 0 : 1)}M`;
+  if (abs >= 1e4) return `${(n / 1e3).toFixed(abs >= 1e5 ? 0 : 1)}K`;
+  if (Number.isInteger(n)) return n.toLocaleString();
+  return n.toLocaleString(undefined, { maximumFractionDigits: 4 });
+};
+
+export const formatNumberExact = (n: number): string => {
+  if (!Number.isFinite(n)) return String(n);
+  return Number.isInteger(n) ? n.toLocaleString() : String(n);
+};
+
+export const coerceNumber = (raw: unknown): number | null => {
+  if (typeof raw === "number") return Number.isFinite(raw) ? raw : null;
+  if (typeof raw === "bigint") return Number(raw);
+  if (typeof raw === "string") {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+};
+
+export const truthyBoolean = (raw: unknown): boolean => {
+  if (typeof raw === "boolean") return raw;
+  if (typeof raw === "number") return raw !== 0;
+  if (typeof raw === "string") {
+    const s = raw.toLowerCase();
+    return s === "t" || s === "true" || s === "1" || s === "y" || s === "yes";
+  }
+  return Boolean(raw);
+};
+
+export const stringifyJson = (value: unknown): string => {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+
+export const stringifyCell = (value: unknown): string => {
+  if (isNullish(value)) return "null";
+  if (typeof value === "object") return stringifyJson(value);
+  return String(value);
+};
+
+export const previewString = (raw: unknown, max = 32): string => {
+  const s = typeof raw === "string" ? raw : stringifyCell(raw);
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1)}…`;
+};

--- a/apps/mobile/lib/errors.ts
+++ b/apps/mobile/lib/errors.ts
@@ -187,25 +187,86 @@ export const formatConnectionError = (error: unknown, dbType: DatabaseType): str
   return rawMessage;
 };
 
-export const formatQueryError = (error: unknown, _dbType: DatabaseType): string => {
-  const rawMessage = error instanceof Error ? error.message : String(error);
+// Strip implementation-detail wrappers that the underlying drivers add. These
+// are noise to a user reading an error: the cause sits after the wrapper and
+// is what they actually need to see.
+const cleanRawMessage = (raw: string): string => {
+  let m = raw;
 
-  const syntaxPatterns = [
-    { pattern: /syntax error/i, message: "SQL syntax error" },
-    { pattern: /column.*does not exist/i, message: "Column not found" },
-    { pattern: /table.*does not exist/i, message: "Table not found" },
-    { pattern: /relation.*does not exist/i, message: "Table or view not found" },
-    { pattern: /permission denied/i, message: "Permission denied" },
-    { pattern: /duplicate key/i, message: "Duplicate key violation" },
-    { pattern: /foreign key/i, message: "Foreign key constraint violation" },
-    { pattern: /null value/i, message: "NULL value not allowed" },
-  ];
+  // expo-sqlite: "Calling the 'prepareAsync' function has failed → Caused by: Error code 1: <real>"
+  const causedByIdx = m.search(/(?:→\s*)?Caused by:\s*/i);
+  if (causedByIdx !== -1) {
+    m = m.slice(causedByIdx).replace(/^(?:→\s*)?Caused by:\s*/i, "");
+  }
+  // expo-sqlite/SQLite: "Error code N: <real>"
+  m = m.replace(/^Error code \d+:\s*/i, "");
+  // node-postgres / generic: "error: <real>"
+  m = m.replace(/^error:\s*/i, "");
+  return m.trim();
+};
 
-  for (const { pattern, message } of syntaxPatterns) {
-    if (pattern.test(rawMessage)) {
-      return `${message}: ${rawMessage}`;
-    }
+const quote = (s: string): string => `"${s}"`;
+
+const buildQueryErrorMessage = (raw: string): string => {
+  const cleaned = cleanRawMessage(raw);
+
+  // SQLite — "no such table: name" / "no such column: name"
+  let match = cleaned.match(/^no such table:\s*(.+)$/i);
+  if (match) return `Table ${quote(match[1].trim())} doesn't exist.`;
+
+  match = cleaned.match(/^no such column:\s*(.+)$/i);
+  if (match) return `Column ${quote(match[1].trim())} doesn't exist.`;
+
+  // Postgres — "relation \"name\" does not exist" / "column \"name\" does not exist"
+  match = cleaned.match(/relation "?([^"\s]+)"? does not exist/i);
+  if (match) return `Table ${quote(match[1])} doesn't exist.`;
+
+  match = cleaned.match(/column "?([^"\s]+)"? does not exist/i);
+  if (match) return `Column ${quote(match[1])} doesn't exist.`;
+
+  // MySQL — "Table 'db.name' doesn't exist" / "Unknown column 'name' in ..."
+  match = cleaned.match(/table '([^']+)' doesn't exist/i);
+  if (match) {
+    const name = match[1].split(".").pop() ?? match[1];
+    return `Table ${quote(name)} doesn't exist.`;
   }
 
-  return rawMessage;
+  match = cleaned.match(/unknown column '([^']+)'/i);
+  if (match) return `Column ${quote(match[1])} doesn't exist.`;
+
+  // Constraint violations
+  if (/duplicate key|UNIQUE constraint failed|Duplicate entry/i.test(cleaned)) {
+    return `Duplicate value violates a unique constraint.`;
+  }
+  if (/foreign key|FOREIGN KEY constraint failed/i.test(cleaned)) {
+    return `Foreign key constraint failed.`;
+  }
+  if (/NOT NULL constraint failed|null value in column/i.test(cleaned)) {
+    return `A required column can't be NULL.`;
+  }
+  if (/CHECK constraint failed/i.test(cleaned)) {
+    return `A CHECK constraint failed.`;
+  }
+
+  // Permission
+  if (/permission denied|access denied/i.test(cleaned)) {
+    return `Permission denied for this query.`;
+  }
+
+  // Syntax
+  if (/syntax error/i.test(cleaned)) {
+    return `SQL syntax error: ${cleaned.replace(/^syntax error[:,]?\s*/i, "")}`.trim();
+  }
+
+  // MongoDB — "Invalid JSON query"
+  if (/invalid json query/i.test(cleaned)) {
+    return cleaned;
+  }
+
+  return cleaned || raw;
+};
+
+export const formatQueryError = (error: unknown, _dbType: DatabaseType): string => {
+  const rawMessage = error instanceof Error ? error.message : String(error);
+  return buildQueryErrorMessage(rawMessage);
 };

--- a/apps/mobile/lib/navigation.ts
+++ b/apps/mobile/lib/navigation.ts
@@ -1,0 +1,14 @@
+import { type Href, router } from "expo-router";
+
+/**
+ * router.back() throws "GO_BACK was not handled" when the screen was reached
+ * via deep link with no back stack to pop. Use this helper instead — it
+ * navigates back when possible and replaces with the fallback otherwise.
+ */
+export const safeBack = (fallback: Href = "/"): void => {
+  if (router.canGoBack()) {
+    router.back();
+    return;
+  }
+  router.replace(fallback);
+};

--- a/apps/mobile/lib/protocols/mock/connection.ts
+++ b/apps/mobile/lib/protocols/mock/connection.ts
@@ -244,7 +244,7 @@ export class MockConnection implements DatabaseConnection {
     return MOCK_TABLES;
   }
 
-  async describeTable(_schema: string, table: string): Promise<ColumnInfo[]> {
+  async describeTable(_schema: string | undefined, table: string): Promise<ColumnInfo[]> {
     await delay(100);
     return MOCK_COLUMNS[table] ?? [];
   }

--- a/apps/mobile/lib/protocols/mongodb/connection.ts
+++ b/apps/mobile/lib/protocols/mongodb/connection.ts
@@ -493,7 +493,7 @@ export class MongoDBConnection implements DatabaseConnection {
     }));
   }
 
-  async describeTable(_schema: string, table: string): Promise<ColumnInfo[]> {
+  async describeTable(_schema: string | undefined, table: string): Promise<ColumnInfo[]> {
     const command: BsonDocument = {
       find: table,
       limit: 1,

--- a/apps/mobile/lib/protocols/mysql/connection.ts
+++ b/apps/mobile/lib/protocols/mysql/connection.ts
@@ -334,7 +334,11 @@ export class MySQLConnection implements DatabaseConnection {
   }
 
   async describeTable(schema: string | undefined, table: string): Promise<ColumnInfo[]> {
-    const safeSchema = escapeMySQLStringLiteral(schema ?? this.config.database);
+    const effectiveSchema = schema ?? this.config.database;
+    if (!effectiveSchema) {
+      throw new Error("describeTable: no schema provided and the connection has no default database");
+    }
+    const safeSchema = escapeMySQLStringLiteral(effectiveSchema);
     const safeTable = escapeMySQLStringLiteral(table);
 
     const result = await this.query(

--- a/apps/mobile/lib/protocols/mysql/connection.ts
+++ b/apps/mobile/lib/protocols/mysql/connection.ts
@@ -336,7 +336,9 @@ export class MySQLConnection implements DatabaseConnection {
   async describeTable(schema: string | undefined, table: string): Promise<ColumnInfo[]> {
     const effectiveSchema = schema ?? this.config.database;
     if (!effectiveSchema) {
-      throw new Error("describeTable: no schema provided and the connection has no default database");
+      throw new Error(
+        "describeTable: no schema provided and the connection has no default database",
+      );
     }
     const safeSchema = escapeMySQLStringLiteral(effectiveSchema);
     const safeTable = escapeMySQLStringLiteral(table);

--- a/apps/mobile/lib/protocols/mysql/connection.ts
+++ b/apps/mobile/lib/protocols/mysql/connection.ts
@@ -333,8 +333,8 @@ export class MySQLConnection implements DatabaseConnection {
     }));
   }
 
-  async describeTable(schema: string, table: string): Promise<ColumnInfo[]> {
-    const safeSchema = escapeMySQLStringLiteral(schema);
+  async describeTable(schema: string | undefined, table: string): Promise<ColumnInfo[]> {
+    const safeSchema = escapeMySQLStringLiteral(schema ?? this.config.database);
     const safeTable = escapeMySQLStringLiteral(table);
 
     const result = await this.query(

--- a/apps/mobile/lib/protocols/postgres/connection.ts
+++ b/apps/mobile/lib/protocols/postgres/connection.ts
@@ -295,8 +295,8 @@ export class PostgresConnection implements DatabaseConnection {
     }));
   }
 
-  async describeTable(schema: string, table: string): Promise<ColumnInfo[]> {
-    const safeSchema = escapePostgresStringLiteral(schema);
+  async describeTable(schema: string | undefined, table: string): Promise<ColumnInfo[]> {
+    const safeSchema = escapePostgresStringLiteral(schema ?? "public");
     const safeTable = escapePostgresStringLiteral(table);
     const result = await this.query(`
       SELECT

--- a/apps/mobile/lib/protocols/sqlite/connection.ts
+++ b/apps/mobile/lib/protocols/sqlite/connection.ts
@@ -128,7 +128,11 @@ export class SQLiteConnection implements DatabaseConnection {
   }
 
   async describeTable(_schema: string | undefined, table: string): Promise<ColumnInfo[]> {
-    const result = await this.query(`PRAGMA table_info('${table}')`);
+    // PRAGMA table_info accepts a string literal; escape `'` to prevent
+    // injection from a hostile sqlite_master entry or any future caller
+    // passing user input.
+    const safeTable = table.replace(/'/g, "''");
+    const result = await this.query(`PRAGMA table_info('${safeTable}')`);
 
     return result.rows.map((row) => ({
       name: row.name as string,

--- a/apps/mobile/lib/protocols/sqlite/connection.ts
+++ b/apps/mobile/lib/protocols/sqlite/connection.ts
@@ -127,7 +127,7 @@ export class SQLiteConnection implements DatabaseConnection {
     }));
   }
 
-  async describeTable(_schema: string, table: string): Promise<ColumnInfo[]> {
+  async describeTable(_schema: string | undefined, table: string): Promise<ColumnInfo[]> {
     const result = await this.query(`PRAGMA table_info('${table}')`);
 
     return result.rows.map((row) => ({

--- a/apps/mobile/lib/storage/results-prefs.ts
+++ b/apps/mobile/lib/storage/results-prefs.ts
@@ -1,0 +1,80 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export type ResultsViewMode = "cards" | "table" | "json";
+
+export interface ColumnPrefs {
+  pinned: string[];
+  hidden: string[];
+}
+
+const VIEW_KEY = "cosmq_results_view_by_connection";
+const COLUMNS_KEY = "cosmq_results_columns_by_query";
+const EDITOR_MODE_KEY = "cosmq_editor_mode_by_connection";
+
+export type EditorMode = "editor" | "builder";
+
+const queryHash = (sql: string): string => {
+  let h = 5381;
+  for (let i = 0; i < sql.length; i++) {
+    h = ((h << 5) + h + sql.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(36);
+};
+
+export const buildPrefsKey = (connectionId: string, sql: string): string =>
+  `${connectionId}:${queryHash(sql.trim())}`;
+
+const readJson = async <T>(key: string, fallback: T): Promise<T> => {
+  try {
+    const raw = await AsyncStorage.getItem(key);
+    if (!raw) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+};
+
+export async function getResultsViewMode(
+  connectionId: string,
+): Promise<ResultsViewMode | null> {
+  const map = await readJson<Record<string, ResultsViewMode>>(VIEW_KEY, {});
+  return map[connectionId] ?? null;
+}
+
+export async function setResultsViewMode(
+  connectionId: string,
+  mode: ResultsViewMode,
+): Promise<void> {
+  const map = await readJson<Record<string, ResultsViewMode>>(VIEW_KEY, {});
+  map[connectionId] = mode;
+  await AsyncStorage.setItem(VIEW_KEY, JSON.stringify(map));
+}
+
+export async function getColumnPrefs(prefsKey: string): Promise<ColumnPrefs> {
+  const map = await readJson<Record<string, ColumnPrefs>>(COLUMNS_KEY, {});
+  return map[prefsKey] ?? { pinned: [], hidden: [] };
+}
+
+export async function setColumnPrefs(
+  prefsKey: string,
+  prefs: ColumnPrefs,
+): Promise<void> {
+  const map = await readJson<Record<string, ColumnPrefs>>(COLUMNS_KEY, {});
+  if (prefs.pinned.length === 0 && prefs.hidden.length === 0) {
+    delete map[prefsKey];
+  } else {
+    map[prefsKey] = prefs;
+  }
+  await AsyncStorage.setItem(COLUMNS_KEY, JSON.stringify(map));
+}
+
+export async function getEditorMode(connectionId: string): Promise<EditorMode | null> {
+  const map = await readJson<Record<string, EditorMode>>(EDITOR_MODE_KEY, {});
+  return map[connectionId] ?? null;
+}
+
+export async function setEditorMode(connectionId: string, mode: EditorMode): Promise<void> {
+  const map = await readJson<Record<string, EditorMode>>(EDITOR_MODE_KEY, {});
+  map[connectionId] = mode;
+  await AsyncStorage.setItem(EDITOR_MODE_KEY, JSON.stringify(map));
+}

--- a/apps/mobile/lib/storage/results-prefs.ts
+++ b/apps/mobile/lib/storage/results-prefs.ts
@@ -50,9 +50,7 @@ const enqueueWrite = (key: string, task: () => Promise<void>): Promise<void> => 
   return next;
 };
 
-export async function getResultsViewMode(
-  connectionId: string,
-): Promise<ResultsViewMode | null> {
+export async function getResultsViewMode(connectionId: string): Promise<ResultsViewMode | null> {
   const map = await readJson<Record<string, ResultsViewMode>>(VIEW_KEY, {});
   return map[connectionId] ?? null;
 }
@@ -73,10 +71,7 @@ export async function getColumnPrefs(prefsKey: string): Promise<ColumnPrefs> {
   return map[prefsKey] ?? { pinned: [], hidden: [] };
 }
 
-export async function setColumnPrefs(
-  prefsKey: string,
-  prefs: ColumnPrefs,
-): Promise<void> {
+export async function setColumnPrefs(prefsKey: string, prefs: ColumnPrefs): Promise<void> {
   return enqueueWrite(COLUMNS_KEY, async () => {
     const map = await readJson<Record<string, ColumnPrefs>>(COLUMNS_KEY, {});
     if (prefs.pinned.length === 0 && prefs.hidden.length === 0) {

--- a/apps/mobile/lib/storage/results-prefs.ts
+++ b/apps/mobile/lib/storage/results-prefs.ts
@@ -34,6 +34,22 @@ const readJson = async <T>(key: string, fallback: T): Promise<T> => {
   }
 };
 
+// Each writer below does read-modify-write on a shared JSON blob keyed by
+// category. Without serialization, two rapid calls (e.g. fast pin/hide
+// toggles, view-mode switch right after) can interleave their reads and the
+// later setItem clobbers the earlier one — silently losing the first update.
+// The chain serializes all writes targeting the same storage key.
+const writeChains: Record<string, Promise<void>> = {};
+
+const enqueueWrite = (key: string, task: () => Promise<void>): Promise<void> => {
+  const prev = writeChains[key] ?? Promise.resolve();
+  const next = prev.catch(() => undefined).then(task);
+  writeChains[key] = next.finally(() => {
+    if (writeChains[key] === next) delete writeChains[key];
+  });
+  return next;
+};
+
 export async function getResultsViewMode(
   connectionId: string,
 ): Promise<ResultsViewMode | null> {
@@ -45,9 +61,11 @@ export async function setResultsViewMode(
   connectionId: string,
   mode: ResultsViewMode,
 ): Promise<void> {
-  const map = await readJson<Record<string, ResultsViewMode>>(VIEW_KEY, {});
-  map[connectionId] = mode;
-  await AsyncStorage.setItem(VIEW_KEY, JSON.stringify(map));
+  return enqueueWrite(VIEW_KEY, async () => {
+    const map = await readJson<Record<string, ResultsViewMode>>(VIEW_KEY, {});
+    map[connectionId] = mode;
+    await AsyncStorage.setItem(VIEW_KEY, JSON.stringify(map));
+  });
 }
 
 export async function getColumnPrefs(prefsKey: string): Promise<ColumnPrefs> {
@@ -59,13 +77,15 @@ export async function setColumnPrefs(
   prefsKey: string,
   prefs: ColumnPrefs,
 ): Promise<void> {
-  const map = await readJson<Record<string, ColumnPrefs>>(COLUMNS_KEY, {});
-  if (prefs.pinned.length === 0 && prefs.hidden.length === 0) {
-    delete map[prefsKey];
-  } else {
-    map[prefsKey] = prefs;
-  }
-  await AsyncStorage.setItem(COLUMNS_KEY, JSON.stringify(map));
+  return enqueueWrite(COLUMNS_KEY, async () => {
+    const map = await readJson<Record<string, ColumnPrefs>>(COLUMNS_KEY, {});
+    if (prefs.pinned.length === 0 && prefs.hidden.length === 0) {
+      delete map[prefsKey];
+    } else {
+      map[prefsKey] = prefs;
+    }
+    await AsyncStorage.setItem(COLUMNS_KEY, JSON.stringify(map));
+  });
 }
 
 export async function getEditorMode(connectionId: string): Promise<EditorMode | null> {
@@ -74,7 +94,9 @@ export async function getEditorMode(connectionId: string): Promise<EditorMode | 
 }
 
 export async function setEditorMode(connectionId: string, mode: EditorMode): Promise<void> {
-  const map = await readJson<Record<string, EditorMode>>(EDITOR_MODE_KEY, {});
-  map[connectionId] = mode;
-  await AsyncStorage.setItem(EDITOR_MODE_KEY, JSON.stringify(map));
+  return enqueueWrite(EDITOR_MODE_KEY, async () => {
+    const map = await readJson<Record<string, EditorMode>>(EDITOR_MODE_KEY, {});
+    map[connectionId] = mode;
+    await AsyncStorage.setItem(EDITOR_MODE_KEY, JSON.stringify(map));
+  });
 }

--- a/apps/mobile/lib/types.ts
+++ b/apps/mobile/lib/types.ts
@@ -78,5 +78,5 @@ export interface DatabaseConnection {
   query(sql: string): Promise<QueryResult>;
   listDatabases(): Promise<DatabaseInfo[]>;
   listTables(schema?: string): Promise<TableInfo[]>;
-  describeTable(schema: string, table: string): Promise<ColumnInfo[]>;
+  describeTable(schema: string | undefined, table: string): Promise<ColumnInfo[]>;
 }


### PR DESCRIPTION
## Summary
- **Results redesign.** Replace the every-result-needs-horizontal-scroll grid with a per-query Cards / Table / JSON switcher (Cards default). Cards expose a PK title chip, copy + expand actions and a `View more (N)` accordion; Table keeps a sticky first column synced to a vertical-scroll ref, with sort affordances and long-press resize; JSON is a collapsible tree with primitive coloring. Header bar hosts row count · ms · COMMAND, segmented switcher, client-side filter, sort/customize/copy-all buttons. Detail sheet + Column Customize sheet + Sort sheet underneath. Per-`(connectionId, queryHash)` pin/hide prefs and per-`connectionId` view choice persist via AsyncStorage.
- **Visual query builder.** New Editor / Builder mode toggle above the SQL editor; in Builder mode the screen renders a tap-driven form (no drag-and-drop) and live-syncs the generated query into the existing `query` state so the Run button is unchanged. SQL builder covers `SELECT * / pick`, `WHERE` with AND/OR and 13 operators (including `IN`, `BETWEEN`, `IS NULL`), `ORDER BY`, `LIMIT` for Postgres / Cockroach / MySQL / MariaDB / SQLite (dialect-aware quoting + literal formatting). MongoDB builder covers collection, projection, filter (10 operators incl. `\$in` / `\$exists` / `\$regex`), sort, limit — emits a JSON `find` command compatible with the existing `MongoDBConnection.query()` parser. Bottom-sheet pickers for tables / columns / operators. Live preview block at the bottom.
- **Friendlier errors and safer navigation.** SQLite's `Calling the 'prepareAsync' function has failed → Caused by: Error code 1: no such table: users` now reads `Table "users" doesn't exist.` Same shape for column-not-found, constraint, syntax, permission, and across PG / MySQL / Mongo. New `safeBack()` helper uses `router.canGoBack()` and falls back to `/`, so deep-link entries to `/connection/new` no longer fire `GO_BACK was not handled by any navigator` after Save. Long Neon hosts on the connection-detail screen no longer overlap the `Host` label.

## Verified live (iPhone 17 Pro, Expo Go, RN 0.81.4 + new arch, SQLite connection)
- Cards default render: PK chip, label/value rows, copy + expand actions.
- Table view: sticky header with type, sort caret affordances, all rows.
- JSON view: collapsible array → objects, strings green, numbers orange.
- Builder mode: SQL builder renders FROM / SELECT / WHERE / ORDER BY / LIMIT with empty-state placeholders; preview reflects live edits.
- Editor / Builder toggle persists across screens via AsyncStorage.
- `SELECT * FROM users` → \`Table \"users\" doesn't exist.\`
- \`SELECT bogus_col FROM (SELECT 1 AS x)\` → \`Column \"bogus_col\" doesn't exist.\`
- Deep-link `/connection/new` → fill → Save → no `GO_BACK` LogBox toast.

## Test plan
- [ ] **Results** — run a multi-row SELECT and toggle Cards / Table / JSON; confirm header bar counts, search filters rows live, sort sheet flips order, customize sheet pins / hides columns and persists per query.
- [ ] **Cards detail** — tap a card to open the detail sheet; copy individual cells; long-press a compact number to see the exact value.
- [ ] **Table** — sticky PK column stays put while horizontally scrolling; long-press a header to enter resize mode and drag the handle; tap a cell to copy.
- [ ] **JSON** — expand / collapse nodes; long-press to copy a node.
- [ ] **Builder (SQL)** — pick a table, pick columns, add WHERE conditions with mixed AND/OR, add ORDER BY, tweak LIMIT; preview updates and Run executes the generated query.
- [ ] **Builder (Mongo)** — pick a collection, project fields, add filters using `\$in` / `\$exists`; preview emits a valid `find` JSON; Run returns documents.
- [ ] **Errors** — `SELECT * FROM nonexistent` and `SELECT bogus_col FROM (SELECT 1 AS x)` produce clean messages (no `prepareAsync`, no `Error code N`).
- [ ] **Navigation** — open the new-connection deep link directly (`exp://…/--/connection/new` or production `cosmq://connection/new`), Save, and confirm the app lands on Connections without a `GO_BACK` toast.
- [ ] **Persistence** — switch view mode, kill the app, return; the view + editor mode + column prefs survive.

## Notes
- All changes are confined to `apps/mobile/` plus a new `lib/navigation.ts` helper. No native module additions, no migrations.
- `tsc --noEmit` passes clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full visual query builder (SQL & Mongo) with per-connection editor/builder toggle and persisted mode
  * Multiple results views (Cards, Table with resizable/sortable columns, JSON tree) plus detail sheet and column-customize sheet
  * Rich cell rendering (copy, JSON view, formatted numbers/dates), expandable cards, pickers/sheets, and preview/preview-panel in builder
  * Per-query persistence for column prefs and results view mode

* **Bug Fixes**
  * Safer back navigation to avoid deep-link back-stack errors
  * Improved, user-friendly query/table error messages
* **UX**
  * Tighter layout and truncation/selectable behavior in connection detail and save/delete flows (better copy/select and navigation)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Adds a full visual query builder (SQL + MongoDB) with live preview, a per-connection Editor/Builder toggle, and AsyncStorage persistence for mode and column prefs; the `executedQuery` state correctly decouples builder edits from `ResultsView`'s prefs key.
- Replaces the flat results grid with a Cards/Table/JSON switcher, per-query column pin/hide prefs, client-side search + sort, and a sticky-column `TableView` with PanResponder resize.
- Delivers friendlier dialect-aware error messages and a `safeBack` helper that prevents deep-link navigation crashes.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

PR is mostly safe but has two P1s: raw error messages in handleExecute (prior review) and LIMIT 0 rendering as empty in SqlBuilder (new finding).

Two P1 defects present — the existing unaddressed `formatQueryError` bypass in `handleExecute`/`executeWithTransaction`, and the newly found `limit === 0` falsy-check that makes `LIMIT 0` silently display as "no limit" while returning zero rows.

apps/mobile/components/builder/SqlBuilder.tsx (LIMIT 0 display), apps/mobile/app/query/[connectionId].tsx (formatQueryError not used in execute paths)
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/mobile/components/builder/SqlBuilder.tsx | New visual SQL query builder component; `LIMIT 0` silently displays as empty (falsy check `state.limit ? ...`) while generating `LIMIT 0` in SQL, which returns zero rows. |
| apps/mobile/app/query/[connectionId].tsx | Major refactor: replaces inline result table with ResultsView, adds Builder/Editor toggle with persistent mode, introduces executedQuery state to decouple builder mutations from result prefs key. `handleExecute` and `executeWithTransaction` still use raw `err.message` instead of `formatQueryError` (flagged in prior review). |
| apps/mobile/components/results/ResultsView.tsx | New Cards/Table/JSON switcher with per-connection view-mode persistence and per-query column prefs. The `executedQuery` prop correctly prevents prefs-key churn during builder edits. `onCopyAll` is still not wrapped in `useCallback` (flagged prior). |
| apps/mobile/components/results/CardsView.tsx | Previously flagged TDZ crash in `stableRowKey` and duplicate-key issues are both resolved: `v` is declared before use and index is appended as a tiebreaker. |
| apps/mobile/lib/errors.ts | Significantly improved error formatting: strips expo-sqlite wrapper noise, maps known patterns to friendly messages per dialect; logic looks correct. |
| apps/mobile/lib/storage/results-prefs.ts | New AsyncStorage persistence for view mode, editor mode, and column prefs; write-chain serialization prevents interleaved updates. Unbounded map growth flagged in prior review remains unaddressed. |
| apps/mobile/lib/navigation.ts | New `safeBack` helper correctly handles deep-link entry by falling back to `router.replace("/")` when there's no back stack. |
| apps/mobile/components/builder/BuilderView.tsx | Orchestrates SQL/MongoDB builder state, table/column loading with request-ID cancellation, and live query emission; previously flagged `"public"` schema default is now handled per-driver. |
| apps/mobile/components/results/TableView.tsx | New Table view with sticky first column, PanResponder-based column resize, and sort affordances; scroll-sync between header and body ScrollViews looks correct. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[QueryScreen] --> B{editorMode}
    B -- editor --> C[SqlEditor]
    B -- builder --> D[BuilderView]
    D --> E[SqlBuilder / MongoBuilder]
    E -- onQueryChange --> A
    C -- onChangeText --> A
    A -- query state --> F[Run Button]
    F --> G[handleExecute / executeWithTransaction]
    G -- success --> H[setResult + setExecutedQuery]
    G -- error --> I[setError raw message]
    H --> J[ResultsView query=executedQuery]
    J --> K{mode}
    K -- cards --> L[CardsView]
    K -- table --> M[TableView]
    K -- json --> N[JsonView]
    J --> O[AsyncStorage view mode + column prefs]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (6)</h3></summary>

1. `apps/mobile/app/query/[connectionId].tsx`, line 1170-1175 ([link](https://github.com/arioberek/cosmq/blob/9692c84087be7cc5c32ffb4c614a97d51fcf3f2b/apps/mobile/app/query/[connectionId].tsx#L1170-L1175)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Live `query` prop resets `ResultsView` sort/filter on every builder interaction**

   `ResultsView` receives `query={query}` where `query` is the same state the builder updates on every tap (via `onQueryChange={setQuery}`). Inside `ResultsView`, `prefsKey` is derived from this prop and the effect that resets `sortColumn`, `sortDir`, and `search` fires every time `prefsKey` changes. This means any builder interaction (picking a table, toggling a column, changing a condition) while results from the last execution are visible immediately clears the user's active sort and search filter, and also hammers AsyncStorage with repeated reads.

   The fix is to persist the *executed* query separately and pass that to `ResultsView`:

   ```
   // outside handleExecute
   const [executedQuery, setExecutedQuery] = useState("");

   // inside handleExecute, just before setResult(queryResult)
   setExecutedQuery(trimmed);

   // in JSX
   <ResultsView
     result={result}
     connectionId={connectionId}
     query={executedQuery}   // ← was: query
     onCopyAll={copyAllResults}
   />
   ```

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fapp%2Fquery%2F%5BconnectionId%5D.tsx%0ALine%3A%201170-1175%0A%0AComment%3A%0A**Live%20%60query%60%20prop%20resets%20%60ResultsView%60%20sort%2Ffilter%20on%20every%20builder%20interaction**%0A%0A%60ResultsView%60%20receives%20%60query%3D%7Bquery%7D%60%20where%20%60query%60%20is%20the%20same%20state%20the%20builder%20updates%20on%20every%20tap%20%28via%20%60onQueryChange%3D%7BsetQuery%7D%60%29.%20Inside%20%60ResultsView%60%2C%20%60prefsKey%60%20is%20derived%20from%20this%20prop%20and%20the%20effect%20that%20resets%20%60sortColumn%60%2C%20%60sortDir%60%2C%20and%20%60search%60%20fires%20every%20time%20%60prefsKey%60%20changes.%20This%20means%20any%20builder%20interaction%20%28picking%20a%20table%2C%20toggling%20a%20column%2C%20changing%20a%20condition%29%20while%20results%20from%20the%20last%20execution%20are%20visible%20immediately%20clears%20the%20user's%20active%20sort%20and%20search%20filter%2C%20and%20also%20hammers%20AsyncStorage%20with%20repeated%20reads.%0A%0AThe%20fix%20is%20to%20persist%20the%20*executed*%20query%20separately%20and%20pass%20that%20to%20%60ResultsView%60%3A%0A%0A%60%60%60%0A%2F%2F%20outside%20handleExecute%0Aconst%20%5BexecutedQuery%2C%20setExecutedQuery%5D%20%3D%20useState%28%22%22%29%3B%0A%0A%2F%2F%20inside%20handleExecute%2C%20just%20before%20setResult%28queryResult%29%0AsetExecutedQuery%28trimmed%29%3B%0A%0A%2F%2F%20in%20JSX%0A%3CResultsView%0A%20%20result%3D%7Bresult%7D%0A%20%20connectionId%3D%7BconnectionId%7D%0A%20%20query%3D%7BexecutedQuery%7D%20%20%20%2F%2F%20%E2%86%90%20was%3A%20query%0A%20%20onCopyAll%3D%7BcopyAllResults%7D%0A%2F%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arioberek%2Fcosmq&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arioberek%2Fcosmq%22%20on%20the%20existing%20branch%20%22feat%2Fmobile-results-builder-redesign%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmobile-results-builder-redesign%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fapp%2Fquery%2F%5BconnectionId%5D.tsx%0ALine%3A%201170-1175%0A%0AComment%3A%0A**Live%20%60query%60%20prop%20resets%20%60ResultsView%60%20sort%2Ffilter%20on%20every%20builder%20interaction**%0A%0A%60ResultsView%60%20receives%20%60query%3D%7Bquery%7D%60%20where%20%60query%60%20is%20the%20same%20state%20the%20builder%20updates%20on%20every%20tap%20%28via%20%60onQueryChange%3D%7BsetQuery%7D%60%29.%20Inside%20%60ResultsView%60%2C%20%60prefsKey%60%20is%20derived%20from%20this%20prop%20and%20the%20effect%20that%20resets%20%60sortColumn%60%2C%20%60sortDir%60%2C%20and%20%60search%60%20fires%20every%20time%20%60prefsKey%60%20changes.%20This%20means%20any%20builder%20interaction%20%28picking%20a%20table%2C%20toggling%20a%20column%2C%20changing%20a%20condition%29%20while%20results%20from%20the%20last%20execution%20are%20visible%20immediately%20clears%20the%20user's%20active%20sort%20and%20search%20filter%2C%20and%20also%20hammers%20AsyncStorage%20with%20repeated%20reads.%0A%0AThe%20fix%20is%20to%20persist%20the%20*executed*%20query%20separately%20and%20pass%20that%20to%20%60ResultsView%60%3A%0A%0A%60%60%60%0A%2F%2F%20outside%20handleExecute%0Aconst%20%5BexecutedQuery%2C%20setExecutedQuery%5D%20%3D%20useState%28%22%22%29%3B%0A%0A%2F%2F%20inside%20handleExecute%2C%20just%20before%20setResult%28queryResult%29%0AsetExecutedQuery%28trimmed%29%3B%0A%0A%2F%2F%20in%20JSX%0A%3CResultsView%0A%20%20result%3D%7Bresult%7D%0A%20%20connectionId%3D%7BconnectionId%7D%0A%20%20query%3D%7BexecutedQuery%7D%20%20%20%2F%2F%20%E2%86%90%20was%3A%20query%0A%20%20onCopyAll%3D%7BcopyAllResults%7D%0A%2F%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `apps/mobile/app/query/[connectionId].tsx`, line 657-675 ([link](https://github.com/arioberek/cosmq/blob/9692c84087be7cc5c32ffb4c614a97d51fcf3f2b/apps/mobile/app/query/[connectionId].tsx#L657-L675)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`copyAllResults` not wrapped in `useCallback`**

   `copyAllResults` is a plain `async` function re-created on every render. Because it's passed as `onCopyAll` to the `memo`-wrapped `ResultsView`, the component will always see a new function reference and skip the memo optimisation. Wrapping it in `useCallback` (with `[result]` as the dependency) would restore the memoisation benefit.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fapp%2Fquery%2F%5BconnectionId%5D.tsx%0ALine%3A%20657-675%0A%0AComment%3A%0A**%60copyAllResults%60%20not%20wrapped%20in%20%60useCallback%60**%0A%0A%60copyAllResults%60%20is%20a%20plain%20%60async%60%20function%20re-created%20on%20every%20render.%20Because%20it's%20passed%20as%20%60onCopyAll%60%20to%20the%20%60memo%60-wrapped%20%60ResultsView%60%2C%20the%20component%20will%20always%20see%20a%20new%20function%20reference%20and%20skip%20the%20memo%20optimisation.%20Wrapping%20it%20in%20%60useCallback%60%20%28with%20%60%5Bresult%5D%60%20as%20the%20dependency%29%20would%20restore%20the%20memoisation%20benefit.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arioberek%2Fcosmq&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arioberek%2Fcosmq%22%20on%20the%20existing%20branch%20%22feat%2Fmobile-results-builder-redesign%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmobile-results-builder-redesign%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fapp%2Fquery%2F%5BconnectionId%5D.tsx%0ALine%3A%20657-675%0A%0AComment%3A%0A**%60copyAllResults%60%20not%20wrapped%20in%20%60useCallback%60**%0A%0A%60copyAllResults%60%20is%20a%20plain%20%60async%60%20function%20re-created%20on%20every%20render.%20Because%20it's%20passed%20as%20%60onCopyAll%60%20to%20the%20%60memo%60-wrapped%20%60ResultsView%60%2C%20the%20component%20will%20always%20see%20a%20new%20function%20reference%20and%20skip%20the%20memo%20optimisation.%20Wrapping%20it%20in%20%60useCallback%60%20%28with%20%60%5Bresult%5D%60%20as%20the%20dependency%29%20would%20restore%20the%20memoisation%20benefit.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

3. `apps/mobile/components/builder/PickerSheet.tsx`, line 1390 ([link](https://github.com/arioberek/cosmq/blob/9692c84087be7cc5c32ffb4c614a97d51fcf3f2b/apps/mobile/components/builder/PickerSheet.tsx#L1390)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Search state not cleared on re-open**

   The `search` state is initialised once and never reset when `open` flips from `true` to `false`. After a user types in the filter, closes the sheet, and reopens it, the previous search term is still applied — the list appears filtered from the start, which is confusing. Add a `useEffect` that clears the search whenever the sheet closes.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fcomponents%2Fbuilder%2FPickerSheet.tsx%0ALine%3A%201390%0A%0AComment%3A%0A**Search%20state%20not%20cleared%20on%20re-open**%0A%0AThe%20%60search%60%20state%20is%20initialised%20once%20and%20never%20reset%20when%20%60open%60%20flips%20from%20%60true%60%20to%20%60false%60.%20After%20a%20user%20types%20in%20the%20filter%2C%20closes%20the%20sheet%2C%20and%20reopens%20it%2C%20the%20previous%20search%20term%20is%20still%20applied%20%E2%80%94%20the%20list%20appears%20filtered%20from%20the%20start%2C%20which%20is%20confusing.%20Add%20a%20%60useEffect%60%20that%20clears%20the%20search%20whenever%20the%20sheet%20closes.%0A%0A%60%60%60suggestion%0A%20%20const%20%5Bsearch%2C%20setSearch%5D%20%3D%20useState%28%22%22%29%3B%0A%0A%20%20useEffect%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28!open%29%20setSearch%28%22%22%29%3B%0A%20%20%7D%2C%20%5Bopen%5D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arioberek%2Fcosmq&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arioberek%2Fcosmq%22%20on%20the%20existing%20branch%20%22feat%2Fmobile-results-builder-redesign%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmobile-results-builder-redesign%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fcomponents%2Fbuilder%2FPickerSheet.tsx%0ALine%3A%201390%0A%0AComment%3A%0A**Search%20state%20not%20cleared%20on%20re-open**%0A%0AThe%20%60search%60%20state%20is%20initialised%20once%20and%20never%20reset%20when%20%60open%60%20flips%20from%20%60true%60%20to%20%60false%60.%20After%20a%20user%20types%20in%20the%20filter%2C%20closes%20the%20sheet%2C%20and%20reopens%20it%2C%20the%20previous%20search%20term%20is%20still%20applied%20%E2%80%94%20the%20list%20appears%20filtered%20from%20the%20start%2C%20which%20is%20confusing.%20Add%20a%20%60useEffect%60%20that%20clears%20the%20search%20whenever%20the%20sheet%20closes.%0A%0A%60%60%60suggestion%0A%20%20const%20%5Bsearch%2C%20setSearch%5D%20%3D%20useState%28%22%22%29%3B%0A%0A%20%20useEffect%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28!open%29%20setSearch%28%22%22%29%3B%0A%20%20%7D%2C%20%5Bopen%5D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

4. `apps/mobile/lib/storage/results-prefs.ts`, line 971-982 ([link](https://github.com/arioberek/cosmq/blob/9692c84087be7cc5c32ffb4c614a97d51fcf3f2b/apps/mobile/lib/storage/results-prefs.ts#L971-L982)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unbounded AsyncStorage map growth**

   Every unique `(connectionId, queryHash)` pair that has ever had non-default column prefs will remain in the stored JSON indefinitely — there is no eviction or cap. `queryHash` is derived from the full SQL text, so each distinct query adds a permanent entry. On a heavily used app this map could grow large enough to noticeably slow AsyncStorage reads and writes. Consider limiting the number of stored entries (e.g. LRU eviction when the map exceeds some threshold like 200 entries) or persisting prefs under a normalised key rather than the full query hash.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Flib%2Fstorage%2Fresults-prefs.ts%0ALine%3A%20971-982%0A%0AComment%3A%0A**Unbounded%20AsyncStorage%20map%20growth**%0A%0AEvery%20unique%20%60%28connectionId%2C%20queryHash%29%60%20pair%20that%20has%20ever%20had%20non-default%20column%20prefs%20will%20remain%20in%20the%20stored%20JSON%20indefinitely%20%E2%80%94%20there%20is%20no%20eviction%20or%20cap.%20%60queryHash%60%20is%20derived%20from%20the%20full%20SQL%20text%2C%20so%20each%20distinct%20query%20adds%20a%20permanent%20entry.%20On%20a%20heavily%20used%20app%20this%20map%20could%20grow%20large%20enough%20to%20noticeably%20slow%20AsyncStorage%20reads%20and%20writes.%20Consider%20limiting%20the%20number%20of%20stored%20entries%20%28e.g.%20LRU%20eviction%20when%20the%20map%20exceeds%20some%20threshold%20like%20200%20entries%29%20or%20persisting%20prefs%20under%20a%20normalised%20key%20rather%20than%20the%20full%20query%20hash.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arioberek%2Fcosmq&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arioberek%2Fcosmq%22%20on%20the%20existing%20branch%20%22feat%2Fmobile-results-builder-redesign%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmobile-results-builder-redesign%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Flib%2Fstorage%2Fresults-prefs.ts%0ALine%3A%20971-982%0A%0AComment%3A%0A**Unbounded%20AsyncStorage%20map%20growth**%0A%0AEvery%20unique%20%60%28connectionId%2C%20queryHash%29%60%20pair%20that%20has%20ever%20had%20non-default%20column%20prefs%20will%20remain%20in%20the%20stored%20JSON%20indefinitely%20%E2%80%94%20there%20is%20no%20eviction%20or%20cap.%20%60queryHash%60%20is%20derived%20from%20the%20full%20SQL%20text%2C%20so%20each%20distinct%20query%20adds%20a%20permanent%20entry.%20On%20a%20heavily%20used%20app%20this%20map%20could%20grow%20large%20enough%20to%20noticeably%20slow%20AsyncStorage%20reads%20and%20writes.%20Consider%20limiting%20the%20number%20of%20stored%20entries%20%28e.g.%20LRU%20eviction%20when%20the%20map%20exceeds%20some%20threshold%20like%20200%20entries%29%20or%20persisting%20prefs%20under%20a%20normalised%20key%20rather%20than%20the%20full%20query%20hash.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

5. `apps/mobile/components/builder/builder-state.ts`, line 2192-2201 ([link](https://github.com/arioberek/cosmq/blob/9692c84087be7cc5c32ffb4c614a97d51fcf3f2b/apps/mobile/components/builder/builder-state.ts#L2192-L2201)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead `void idx` suppression**

   `idx` is declared as the second parameter of the `forEach` callback but never read; the trailing `void idx` is only there to suppress the lint warning. A cleaner approach is to either rename it `_idx` or switch to `for...of` and drop the parameter entirely.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fcomponents%2Fbuilder%2Fbuilder-state.ts%0ALine%3A%202192-2201%0A%0AComment%3A%0A**Dead%20%60void%20idx%60%20suppression**%0A%0A%60idx%60%20is%20declared%20as%20the%20second%20parameter%20of%20the%20%60forEach%60%20callback%20but%20never%20read%3B%20the%20trailing%20%60void%20idx%60%20is%20only%20there%20to%20suppress%20the%20lint%20warning.%20A%20cleaner%20approach%20is%20to%20either%20rename%20it%20%60_idx%60%20or%20switch%20to%20%60for...of%60%20and%20drop%20the%20parameter%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20for%20%28const%20cond%20of%20state.conditions%29%20%7B%0A%20%20%20%20%20%20const%20rendered%20%3D%20renderSqlCondition%28cond%2C%20type%29%3B%0A%20%20%20%20%20%20if%20%28!rendered%29%20continue%3B%0A%20%20%20%20%20%20if%20%28parts.length%20%3D%3D%3D%200%29%20%7B%0A%20%20%20%20%20%20%20%20parts.push%28rendered%29%3B%0A%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20parts.push%28%60%24%7Bcond.combinator%7D%20%24%7Brendered%7D%60%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arioberek%2Fcosmq&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arioberek%2Fcosmq%22%20on%20the%20existing%20branch%20%22feat%2Fmobile-results-builder-redesign%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmobile-results-builder-redesign%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fcomponents%2Fbuilder%2Fbuilder-state.ts%0ALine%3A%202192-2201%0A%0AComment%3A%0A**Dead%20%60void%20idx%60%20suppression**%0A%0A%60idx%60%20is%20declared%20as%20the%20second%20parameter%20of%20the%20%60forEach%60%20callback%20but%20never%20read%3B%20the%20trailing%20%60void%20idx%60%20is%20only%20there%20to%20suppress%20the%20lint%20warning.%20A%20cleaner%20approach%20is%20to%20either%20rename%20it%20%60_idx%60%20or%20switch%20to%20%60for...of%60%20and%20drop%20the%20parameter%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20for%20%28const%20cond%20of%20state.conditions%29%20%7B%0A%20%20%20%20%20%20const%20rendered%20%3D%20renderSqlCondition%28cond%2C%20type%29%3B%0A%20%20%20%20%20%20if%20%28!rendered%29%20continue%3B%0A%20%20%20%20%20%20if%20%28parts.length%20%3D%3D%3D%200%29%20%7B%0A%20%20%20%20%20%20%20%20parts.push%28rendered%29%3B%0A%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20parts.push%28%60%24%7Bcond.combinator%7D%20%24%7Brendered%7D%60%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

6. `apps/mobile/app/query/[connectionId].tsx`, line 970-972 ([link](https://github.com/arioberek/cosmq/blob/403d1f8fdcfdad4f78f8317647b59e6d3c2d9c7f/apps/mobile/app/query/[connectionId].tsx#L970-L972)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Query-execution errors bypass `formatQueryError`**

   `handleExecute` (and `executeWithTransaction`) set `error` using the raw `err.message` string, so the friendly error-message feature only applies to the table/column-loading dialogs, not the main query path. A SQLite run on a non-existent table will still surface `Calling the 'prepareAsync' function has failed → Caused by: Error code 1: no such table: users` instead of `Table "users" doesn't exist.` — which contradicts the PR description.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fapp%2Fquery%2F%5BconnectionId%5D.tsx%0ALine%3A%20970-972%0A%0AComment%3A%0A**Query-execution%20errors%20bypass%20%60formatQueryError%60**%0A%0A%60handleExecute%60%20%28and%20%60executeWithTransaction%60%29%20set%20%60error%60%20using%20the%20raw%20%60err.message%60%20string%2C%20so%20the%20friendly%20error-message%20feature%20only%20applies%20to%20the%20table%2Fcolumn-loading%20dialogs%2C%20not%20the%20main%20query%20path.%20A%20SQLite%20run%20on%20a%20non-existent%20table%20will%20still%20surface%20%60Calling%20the%20'prepareAsync'%20function%20has%20failed%20%E2%86%92%20Caused%20by%3A%20Error%20code%201%3A%20no%20such%20table%3A%20users%60%20instead%20of%20%60Table%20%22users%22%20doesn't%20exist.%60%20%E2%80%94%20which%20contradicts%20the%20PR%20description.%0A%0A%60%60%60suggestion%0A%20%20%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20%20%20haptic.error%28%29%3B%0A%20%20%20%20%20%20setError%28formatQueryError%28err%2C%20connection.config.type%29%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arioberek%2Fcosmq&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arioberek%2Fcosmq%22%20on%20the%20existing%20branch%20%22feat%2Fmobile-results-builder-redesign%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmobile-results-builder-redesign%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fapp%2Fquery%2F%5BconnectionId%5D.tsx%0ALine%3A%20970-972%0A%0AComment%3A%0A**Query-execution%20errors%20bypass%20%60formatQueryError%60**%0A%0A%60handleExecute%60%20%28and%20%60executeWithTransaction%60%29%20set%20%60error%60%20using%20the%20raw%20%60err.message%60%20string%2C%20so%20the%20friendly%20error-message%20feature%20only%20applies%20to%20the%20table%2Fcolumn-loading%20dialogs%2C%20not%20the%20main%20query%20path.%20A%20SQLite%20run%20on%20a%20non-existent%20table%20will%20still%20surface%20%60Calling%20the%20'prepareAsync'%20function%20has%20failed%20%E2%86%92%20Caused%20by%3A%20Error%20code%201%3A%20no%20such%20table%3A%20users%60%20instead%20of%20%60Table%20%22users%22%20doesn't%20exist.%60%20%E2%80%94%20which%20contradicts%20the%20PR%20description.%0A%0A%60%60%60suggestion%0A%20%20%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20%20%20haptic.error%28%29%3B%0A%20%20%20%20%20%20setError%28formatQueryError%28err%2C%20connection.config.type%29%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fmobile%2Fcomponents%2Fbuilder%2FSqlBuilder.tsx%3A325%0A**%60LIMIT%200%60%20silently%20misrepresents%20as%20%22no%20limit%22%20in%20the%20UI**%0A%0AThe%20%60TextInput%60%20value%20is%20bound%20to%20%60state.limit%20%3F%20String%28state.limit%29%20%3A%20%22%22%60.%20Because%20%600%60%20is%20falsy%2C%20%60state.limit%20%3D%3D%3D%200%60%20renders%20the%20field%20as%20empty%20%E2%80%94%20identical%20to%20the%20%22No%20limit%22%20placeholder.%20Meanwhile%20%60sqlBuilderToString%60%20emits%20%60LIMIT%200%60%20%28valid%20SQL%20that%20returns%20**zero%20rows**%29%2C%20and%20the%20preview%20block%20does%20show%20it.%20A%20user%20who%20types%20%600%60%20sees%20their%20keystroke%20immediately%20vanish%20from%20the%20input%20while%20the%20query%20silently%20becomes%20one%20that%20returns%20nothing.%0A%0AFix%20the%20guard%20to%20use%20%60state.limit%20!%3D%3D%20null%60%20instead%20of%20the%20truthiness%20check%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20value%3D%7Bstate.limit%20!%3D%3D%20null%20%3F%20String%28state.limit%29%20%3A%20%22%22%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fmobile%2Fcomponents%2Fbuilder%2FMongoBuilder.tsx%3A294%0A**Same%20falsy-zero%20display%20bug%20as%20SqlBuilder**%0A%0A%60state.limit%20%3D%3D%3D%200%60%20renders%20as%20%60%22%22%60%20here%20too.%20For%20MongoDB%2C%20%60limit%3A%200%60%20means%20%22no%20limit%22%20%28consistent%20with%20an%20empty%20display%29%2C%20but%20the%20pattern%20mirrors%20the%20confusing%20UX%20from%20SqlBuilder.%20Align%20with%20the%20SqlBuilder%20fix%20for%20consistency%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20value%3D%7Bstate.limit%20!%3D%3D%20null%20%3F%20String%28state.limit%29%20%3A%20%22%22%7D%0A%60%60%60%0A%0A&repo=arioberek%2Fcosmq&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arioberek%2Fcosmq%22%20on%20the%20existing%20branch%20%22feat%2Fmobile-results-builder-redesign%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmobile-results-builder-redesign%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fmobile%2Fcomponents%2Fbuilder%2FSqlBuilder.tsx%3A325%0A**%60LIMIT%200%60%20silently%20misrepresents%20as%20%22no%20limit%22%20in%20the%20UI**%0A%0AThe%20%60TextInput%60%20value%20is%20bound%20to%20%60state.limit%20%3F%20String%28state.limit%29%20%3A%20%22%22%60.%20Because%20%600%60%20is%20falsy%2C%20%60state.limit%20%3D%3D%3D%200%60%20renders%20the%20field%20as%20empty%20%E2%80%94%20identical%20to%20the%20%22No%20limit%22%20placeholder.%20Meanwhile%20%60sqlBuilderToString%60%20emits%20%60LIMIT%200%60%20%28valid%20SQL%20that%20returns%20**zero%20rows**%29%2C%20and%20the%20preview%20block%20does%20show%20it.%20A%20user%20who%20types%20%600%60%20sees%20their%20keystroke%20immediately%20vanish%20from%20the%20input%20while%20the%20query%20silently%20becomes%20one%20that%20returns%20nothing.%0A%0AFix%20the%20guard%20to%20use%20%60state.limit%20!%3D%3D%20null%60%20instead%20of%20the%20truthiness%20check%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20value%3D%7Bstate.limit%20!%3D%3D%20null%20%3F%20String%28state.limit%29%20%3A%20%22%22%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fmobile%2Fcomponents%2Fbuilder%2FMongoBuilder.tsx%3A294%0A**Same%20falsy-zero%20display%20bug%20as%20SqlBuilder**%0A%0A%60state.limit%20%3D%3D%3D%200%60%20renders%20as%20%60%22%22%60%20here%20too.%20For%20MongoDB%2C%20%60limit%3A%200%60%20means%20%22no%20limit%22%20%28consistent%20with%20an%20empty%20display%29%2C%20but%20the%20pattern%20mirrors%20the%20confusing%20UX%20from%20SqlBuilder.%20Align%20with%20the%20SqlBuilder%20fix%20for%20consistency%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20value%3D%7Bstate.limit%20!%3D%3D%20null%20%3F%20String%28state.limit%29%20%3A%20%22%22%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (8): Last reviewed commit: ["fix(mobile): repair stableRowKey after b..."](https://github.com/arioberek/cosmq/commit/8ddfa68ae5c52af70ac15b4c03d0ed255674ab3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31375780)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->