### PR TITLE
refactor(landing): editorial design pass — Geist, real marquee, token-driven

### DIFF
--- a/apps/landing/.gitignore
+++ b/apps/landing/.gitignore
@@ -22,3 +22,4 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+.firecrawl/

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -11,6 +11,9 @@
 	"dependencies": {
 		"@astrojs/cloudflare": "^12.6.12",
 		"@astrojs/react": "^4.4.2",
+		"@fontsource-variable/geist": "^5.2.8",
+		"@fontsource-variable/geist-mono": "^5.2.7",
+		"@fontsource/instrument-serif": "^5.2.8",
 		"@types/react": "^19.2.7",
 		"@types/react-dom": "^19.2.3",
 		"astro": "^5.16.6",

--- a/apps/landing/src/components/database-marquee.tsx
+++ b/apps/landing/src/components/database-marquee.tsx
@@ -1,5 +1,4 @@
 import { motion } from "motion/react";
-import { useCallback, useRef } from "react";
 import { Icons } from "./icons";
 
 const databases = [
@@ -11,164 +10,113 @@ const databases = [
 	{ icon: Icons.mariadb, name: "MariaDB" },
 ];
 
-function SpotlightGrid() {
-	const gridRef = useRef<HTMLDivElement>(null);
-
-	const handleMouseMove = useCallback((e: React.MouseEvent) => {
-		const grid = gridRef.current;
-		if (!grid) return;
-		const rect = grid.getBoundingClientRect();
-		grid.style.setProperty("--spot-x", `${e.clientX - rect.left}px`);
-		grid.style.setProperty("--spot-y", `${e.clientY - rect.top}px`);
-	}, []);
-
-	const handleMouseLeave = useCallback(() => {
-		const grid = gridRef.current;
-		if (!grid) return;
-		grid.style.setProperty("--spot-x", `-1000px`);
-		grid.style.setProperty("--spot-y", `-1000px`);
-	}, []);
-
-	return (
-		<div
-			ref={gridRef}
-			className="grid grid-cols-2 md:grid-cols-3 gap-[1px] relative db-spotlight-grid"
-			onMouseMove={handleMouseMove}
-			onMouseLeave={handleMouseLeave}
-			style={
-				{
-					"--spot-x": "-1000px",
-					"--spot-y": "-1000px",
-				} as React.CSSProperties
-			}
-		>
-			{databases.map((db, i) => (
-				<motion.div
-					key={db.name}
-					className="relative overflow-hidden db-spot-card"
-					initial={{ opacity: 0, y: 28, filter: "blur(6px)" }}
-					whileInView={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-					viewport={{ once: true }}
-					transition={{
-						duration: 0.5,
-						delay: 0.08 + i * 0.07,
-						ease: [0.22, 1, 0.36, 1],
-					}}
-				>
-					{/* Spotlight border glow — positioned via CSS custom props */}
-					<div className="db-spot-glow" />
-
-					{/* Card content */}
-					<div className="relative z-10 flex flex-col items-center gap-4 py-10 md:py-14 px-4 bg-[#08080d] m-[1px] rounded-[inherit]">
-						<div className="w-14 h-14 md:w-16 md:h-16 rounded-xl border border-white/[0.05] bg-white/[0.02] flex items-center justify-center">
-							<db.icon
-								className="w-7 h-7 md:w-8 md:h-8 brightness-0 invert opacity-50"
-								aria-hidden="true"
-							/>
-						</div>
-						<span className="text-[11px] font-medium text-[#555] tracking-[0.14em] uppercase">
-							{db.name}
-						</span>
-					</div>
-				</motion.div>
-			))}
-		</div>
-	);
-}
+// Duplicated track for seamless infinite loop.
+const track = [...databases, ...databases];
 
 export function DatabaseMarquee() {
 	return (
-		<section className="relative py-32 overflow-hidden">
-			<div className="absolute top-0 left-1/2 -translate-x-1/2 w-[200px] h-px bg-gradient-to-r from-transparent via-white/[0.08] to-transparent" />
+		<section className="relative py-24 md:py-32 overflow-hidden">
+			<div className="absolute top-0 left-1/2 -translate-x-1/2 w-[200px] h-px bg-gradient-to-r from-transparent via-border to-transparent" />
 
 			<motion.div
-				className="text-center mb-16 px-6"
-				initial={{ opacity: 0, y: 20 }}
+				className="text-center mb-14 md:mb-16 px-6"
+				initial={{ opacity: 0, y: 16 }}
 				whileInView={{ opacity: 1, y: 0 }}
 				viewport={{ once: true }}
 				transition={{ duration: 0.6 }}
 			>
-				<span className="inline-block text-[11px] font-mono uppercase tracking-[0.3em] text-[#555] mb-5">
-					Integrations
+				<span className="eyebrow mb-6 justify-center">
+					<span className="eyebrow-num">03</span>
+					<span className="eyebrow-rule" />
+					<span>Databases</span>
 				</span>
-				<h2 className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] text-white mb-4">
-					Every database you need
+				<h2 className="text-[clamp(2rem,5vw,3.25rem)] font-bold tracking-[-0.03em] leading-[1.1] text-foreground mb-4">
+					Talks to <span className="font-display font-normal">your stack.</span>
 				</h2>
-				<p className="text-[#555] text-base max-w-[460px] mx-auto leading-relaxed">
-					First-class support for the databases that power your stack.
+				<p className="text-muted-foreground text-base max-w-[460px] mx-auto leading-relaxed">
+					First-class support for the databases that already run your app.
 				</p>
 			</motion.div>
 
-			<div className="max-w-[820px] mx-auto px-6">
-				<SpotlightGrid />
+			<div className="db-marquee-mask">
+				<div className="db-marquee-track" aria-hidden="false" role="list">
+					{track.map((db, i) => (
+						<div key={`${db.name}-${i}`} role="listitem" className="db-marquee-item">
+							<div className="db-marquee-icon">
+								<db.icon
+									className="w-7 h-7 md:w-8 md:h-8 brightness-0 invert opacity-70"
+									width={32}
+									height={32}
+									alt=""
+								/>
+							</div>
+							<span className="font-mono text-[12px] md:text-[13px] tracking-[0.16em] uppercase text-muted-foreground whitespace-nowrap">
+								{db.name}
+							</span>
+						</div>
+					))}
+				</div>
 			</div>
 
 			<style>{`
-				.db-spot-card {
-					border-radius: 16px;
-					background: transparent;
+				.db-marquee-mask {
+					position: relative;
+					overflow: hidden;
+					-webkit-mask-image: linear-gradient(to right, transparent 0, black 80px, black calc(100% - 80px), transparent 100%);
+					        mask-image: linear-gradient(to right, transparent 0, black 80px, black calc(100% - 80px), transparent 100%);
 				}
 
-				/* The glow layer — a radial gradient positioned at the cursor */
-				.db-spot-glow {
-					position: absolute;
-					inset: 0;
-					border-radius: inherit;
-					opacity: 0;
-					background: radial-gradient(
-						300px circle at var(--spot-x) var(--spot-y),
-						rgba(56, 189, 248, 0.12),
-						transparent 70%
-					);
-					z-index: 0;
-					transition: opacity 0.4s ease;
-					pointer-events: none;
+				.db-marquee-track {
+					display: flex;
+					gap: 3rem;
+					width: max-content;
+					padding: 0.5rem 0;
+					animation: db-marquee 32s linear infinite;
+					will-change: transform;
+				}
+				.db-marquee-mask:hover .db-marquee-track {
+					animation-play-state: paused;
 				}
 
-				/* Border glow via the card itself as a gradient background */
-				.db-spot-card::before {
-					content: "";
-					position: absolute;
-					inset: 0;
-					border-radius: inherit;
-					background: radial-gradient(
-						400px circle at var(--spot-x) var(--spot-y),
-						rgba(56, 189, 248, 0.25),
-						transparent 60%
-					);
-					opacity: 0;
-					transition: opacity 0.4s ease;
-					z-index: 1;
-					pointer-events: none;
+				@keyframes db-marquee {
+					from { transform: translateX(0); }
+					to   { transform: translateX(-50%); }
 				}
 
-				.db-spotlight-grid:hover .db-spot-glow,
-				.db-spotlight-grid:hover .db-spot-card::before {
-					opacity: 1;
+				.db-marquee-item {
+					display: inline-flex;
+					align-items: center;
+					gap: 0.875rem;
+					padding: 0.5rem 1rem;
+					flex-shrink: 0;
 				}
 
-				/* Mobile: subtle shimmer border instead of cursor tracking */
-				@media (hover: none) {
-					.db-spot-card::before {
-						opacity: 0 !important;
+				.db-marquee-icon {
+					display: inline-flex;
+					align-items: center;
+					justify-content: center;
+					width: 44px;
+					height: 44px;
+					border-radius: 12px;
+					background: hsl(var(--surface-1));
+					border: 1px solid hsl(var(--border));
+					flex-shrink: 0;
+				}
+
+				@media (min-width: 768px) {
+					.db-marquee-icon {
+						width: 52px;
+						height: 52px;
 					}
-					.db-spot-glow {
-						opacity: 0 !important;
-					}
-					.db-spot-card {
-						background: rgba(255,255,255,0.03);
-						border: 1px solid rgba(255,255,255,0.05);
-					}
-					.db-spot-card > div:last-child {
-						margin: 0;
-						background: transparent;
+					.db-marquee-track {
+						gap: 4rem;
 					}
 				}
 
 				@media (prefers-reduced-motion: reduce) {
-					.db-spot-glow,
-					.db-spot-card::before {
-						transition: none !important;
+					.db-marquee-track {
+						animation: none;
+						transform: translateX(0);
 					}
 				}
 			`}</style>

--- a/apps/landing/src/components/features-section.tsx
+++ b/apps/landing/src/components/features-section.tsx
@@ -1,133 +1,111 @@
 import { Cable, type LucideIcon, ShieldCheck, Smartphone, SquareTerminal } from "lucide-react";
-import { motion, useScroll, useTransform } from "motion/react";
-import { useRef } from "react";
+import { motion } from "motion/react";
 
 interface Feature {
 	title: string;
 	description: string;
 	Icon: LucideIcon;
 	accent: string;
-	gradient: string;
 }
 
 const features: Feature[] = [
 	{
 		title: "Direct TCP",
 		description:
-			"Connect directly to your database servers using native TCP sockets. No intermediate APIs, no proxy servers, no compromises.",
+			"Native TCP sockets, straight to your database. No proxy server in front, no REST shim, no third-party in between.",
 		Icon: Cable,
-		accent: "#38bdf8",
-		gradient: "from-[#38bdf8]/10 to-transparent",
+		accent: "hsl(var(--alien-1))",
 	},
 	{
-		title: "Secure Storage",
+		title: "Stays on device",
 		description:
-			"Credentials never leave your device. Passwords are encrypted using your device's native secure enclave — Keychain on iOS, Keystore on Android.",
+			"Credentials are encrypted with the platform secure enclave — Keychain on iOS, Keystore on Android. Nothing leaves your phone.",
 		Icon: ShieldCheck,
 		accent: "#34d399",
-		gradient: "from-[#34d399]/10 to-transparent",
 	},
 	{
-		title: "Universal",
+		title: "iOS, Android, Web",
 		description:
-			"Built for iOS, Android, and Web. One consistent, high-performance interface across every device you own.",
+			"One consistent client across every device you carry. Pick up a query on the train, finish it on the laptop.",
 		Icon: Smartphone,
 		accent: "#60a5fa",
-		gradient: "from-[#60a5fa]/10 to-transparent",
 	},
 	{
-		title: "SQL Editor",
+		title: "SQL editor that fits a phone",
 		description:
-			"Full-featured SQL editor with syntax highlighting, history, and results visualization — optimized for mobile screens.",
+			"Syntax highlighting, history, results table — designed for thumbs first, not retrofitted from a desktop IDE.",
 		Icon: SquareTerminal,
-		accent: "#c084fc",
-		gradient: "from-[#c084fc]/10 to-transparent",
+		accent: "hsl(var(--alien-3))",
 	},
 ];
 
-function FeatureCard({ feature, index }: { feature: Feature; index: number }) {
+function FeatureRow({ feature, index }: { feature: Feature; index: number }) {
 	const { Icon, title, description, accent } = feature;
 	const num = String(index + 1).padStart(2, "0");
-	const ref = useRef<HTMLDivElement>(null);
-
-	const { scrollYProgress } = useScroll({
-		target: ref,
-		offset: ["start end", "center center"],
-	});
-
-	const y = useTransform(scrollYProgress, [0, 1], [60, 0]);
-	const opacity = useTransform(scrollYProgress, [0, 0.6], [0, 1]);
-	const scale = useTransform(scrollYProgress, [0, 1], [0.96, 1]);
 
 	return (
-		<motion.div ref={ref} style={{ y, opacity, scale }} className="group relative">
-			<div className="relative rounded-2xl border border-white/[0.05] bg-white/[0.02] p-8 md:p-10 overflow-hidden backdrop-blur-sm hover:border-white/[0.1] transition-colors duration-500">
-				{/* Gradient glow on hover */}
+		<motion.article
+			initial={{ opacity: 0, y: 24 }}
+			whileInView={{ opacity: 1, y: 0 }}
+			viewport={{ once: true, margin: "-80px" }}
+			transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+			className="relative grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-10 py-12 md:py-16 border-t border-border"
+		>
+			<div className="md:col-span-2 flex md:flex-col items-center md:items-start gap-4">
+				<span className="font-mono text-[12px] tracking-[0.2em] text-foreground/50">{num}</span>
 				<div
-					className={`absolute inset-0 bg-gradient-to-br ${feature.gradient} opacity-0 group-hover:opacity-100 transition-opacity duration-700`}
-				/>
-
-				<div className="relative z-10">
-					{/* Number + icon row */}
-					<div className="flex items-start justify-between mb-8">
-						<span
-							className="text-[64px] md:text-[80px] font-black leading-none tracking-tighter"
-							style={{ color: `${accent}10` }}
-						>
-							{num}
-						</span>
-						<motion.div
-							whileHover={{ rotate: -8, scale: 1.1 }}
-							transition={{ type: "spring", stiffness: 400, damping: 15 }}
-							className="flex items-center justify-center w-14 h-14 rounded-2xl mt-2"
-							style={{
-								background: `${accent}12`,
-								border: `1px solid ${accent}20`,
-							}}
-						>
-							<Icon className="w-6 h-6" style={{ color: accent }} strokeWidth={1.5} />
-						</motion.div>
-					</div>
-
-					<h3 className="text-2xl md:text-3xl font-bold text-white tracking-tight mb-3">{title}</h3>
-					<p className="text-[15px] text-[#666] leading-[1.7] m-0 max-w-[400px]">{description}</p>
+					className="flex items-center justify-center w-11 h-11 rounded-lg border"
+					style={{
+						background: `${accent.startsWith("hsl") ? accent.replace(")", " / 0.08)") : `${accent}15`}`,
+						borderColor: `${accent.startsWith("hsl") ? accent.replace(")", " / 0.18)") : `${accent}26`}`,
+					}}
+				>
+					<Icon className="w-[18px] h-[18px]" style={{ color: accent }} strokeWidth={1.6} />
 				</div>
 			</div>
-		</motion.div>
+
+			<h3 className="md:col-span-4 text-[clamp(1.5rem,3vw,2rem)] font-bold tracking-[-0.02em] leading-[1.15] text-foreground">
+				{title}
+			</h3>
+
+			<p className="md:col-span-6 text-[15px] md:text-base text-muted-foreground leading-[1.7] max-w-[520px]">
+				{description}
+			</p>
+		</motion.article>
 	);
 }
 
 export function FeaturesSection() {
 	return (
-		<section id="features" className="relative py-32 px-6 lg:px-10">
-			<div className="max-w-[1400px] mx-auto">
-				{/* Section header */}
-				<div className="mb-20 max-w-[640px]">
+		<section id="features" className="relative py-24 md:py-32 px-6 lg:px-10">
+			<div className="max-w-[1280px] mx-auto">
+				<div className="mb-16 md:mb-20 max-w-[640px]">
 					<motion.span
-						initial={{ opacity: 0, x: -10 }}
-						whileInView={{ opacity: 1, x: 0 }}
+						initial={{ opacity: 0 }}
+						whileInView={{ opacity: 1 }}
 						viewport={{ once: true }}
 						transition={{ duration: 0.5 }}
-						className="inline-block text-[11px] font-mono uppercase tracking-[0.3em] text-[#555] mb-5"
+						className="eyebrow mb-6"
 					>
-						Features
+						<span className="eyebrow-num">01</span>
+						<span className="eyebrow-rule" />
+						<span>Why it works</span>
 					</motion.span>
 					<motion.h2
-						initial={{ opacity: 0, y: 20 }}
+						initial={{ opacity: 0, y: 16 }}
 						whileInView={{ opacity: 1, y: 0 }}
 						viewport={{ once: true }}
 						transition={{ duration: 0.6, delay: 0.1 }}
-						className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] text-white"
+						className="text-[clamp(2rem,5vw,3.25rem)] font-bold tracking-[-0.03em] leading-[1.1] text-foreground"
 					>
-						Built for engineers
-						<span className="text-[#444]"> who ship from anywhere.</span>
+						Four reasons it actually <span className="font-display font-normal">works</span> on a
+						phone.
 					</motion.h2>
 				</div>
 
-				{/* Feature grid */}
-				<div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-5">
+				<div className="border-b border-border">
 					{features.map((feature, i) => (
-						<FeatureCard key={feature.title} feature={feature} index={i} />
+						<FeatureRow key={feature.title} feature={feature} index={i} />
 					))}
 				</div>
 			</div>

--- a/apps/landing/src/components/hero-section.tsx
+++ b/apps/landing/src/components/hero-section.tsx
@@ -1,10 +1,9 @@
-import { motion, useMotionValue, useSpring, useTransform } from "motion/react";
-import { useCallback, useEffect, useRef } from "react";
+import { motion, useMotionValue, useSpring } from "motion/react";
+import { useCallback, useRef } from "react";
 import { PhoneMockup } from "./phone-mockup";
 
-// ── Full alien SVG paths (from apps/mobile/assets/logos/alien.svg) ──
-// These are compound paths designed for FILL rendering — stroke-only
-// breaks them because internal subpaths become visible overlapping lines.
+// Compound paths from apps/mobile/assets/logos/alien.svg.
+// Internal subpaths require fill rendering — stroke would expose them.
 const ALIEN_PATHS = [
 	"M304.99 35.3894C310.965 34.436 322.252 36.267 328.361 37.8403C348.307 42.9776 365.434 54.8974 375.95 72.8141C387.305 92.1617 389.441 116.202 383.647 137.679C376.676 163.518 358.788 193.441 335.183 207.136C336.086 209.713 337.637 213.529 338.039 216.107C338.599 219.695 338.411 223.62 339.429 227.189C340.788 231.954 343.119 236.251 345.005 240.76C347.709 247.226 350.45 253.459 353.363 259.831C362.187 256.159 370.9 252.224 379.487 248.03C379.231 243.441 379.239 239.59 380.637 235.167C382.244 230.084 384.687 223.611 389.738 221.03C392.988 219.37 396.928 218.996 400.373 220.126C402.403 214.958 407.451 201.816 412.252 199.35C418.214 197.449 427.785 203.458 432.715 205.228C450.111 211.472 451.122 213.799 443.359 230.741C447.956 234.09 451.561 240.626 445.957 245.03C444.895 245.864 443.732 246.399 442.527 246.994C443.211 252.718 442.787 254.568 437.863 257.565C437.995 263.087 437.329 264.74 432.418 267.361C432.457 274.148 429.387 277.402 422.501 276.431C417.35 286.592 411.689 283.178 403.231 279.421C401.933 278.845 400.609 278.222 399.318 277.628C394.154 280.66 387.995 283.764 382.605 286.579C372.987 291.457 363.407 296.894 352.898 299.615C336.55 303.848 327.85 289.529 320.179 277.976C316.098 284.058 309.743 288.503 305.612 293.547C303.985 295.533 298.26 307.588 296.799 310.675C293.516 317.609 288.032 327.118 285.287 334.092C299.292 344.8 315.994 354.411 328.558 366.942C334.471 372.84 339.581 389.533 342.77 397.869C346.492 407.578 350.268 417.265 354.098 426.93C357.242 434.857 359.936 442.25 364.172 449.666C377.176 448.644 390.2 443.679 403.216 447.088C408.258 448.409 413.466 453.695 411.337 459.117C408.276 466.915 398.238 471.924 391.276 475.85C386.458 478.566 381.33 480.727 376.438 483.3C367.962 487.417 354.235 495.366 344.772 492.492C336.585 490.007 333.108 475.63 329.546 468.51C326.298 462.396 322.811 457.569 318.928 451.88C312.063 441.822 304.737 431.987 298.841 421.323C297.146 418.208 295.543 415.043 294.034 411.834C287.074 397.063 289.729 398.579 273.857 391.797C263.716 387.463 252.839 382.102 242.742 377.501C238.348 381.505 234.324 385.906 230.104 390.092C222.335 397.798 213.891 405.426 204.679 411.387C199.629 414.655 193.929 417.32 187.879 417.938C174.587 419.298 159.626 412.192 147.429 407.484C141.661 405.258 135.836 403.204 130.022 401.102C125.894 399.609 121.665 397.851 117.357 396.969C108.189 395.092 101.777 401.726 94.7441 406.334C90.4454 409.151 84.9599 411.877 79.6692 410.686C77.1261 410.113 74.4974 408.485 73.1313 406.229C71.2606 403.142 71.415 399.267 72.2124 395.872C74.7375 385.119 91.1721 361.125 100.626 355.404C103.903 353.422 107.637 352.775 111.402 353.502C117.852 354.749 121.385 360.856 127.515 362.683C133.287 364.404 139.513 364.751 145.447 365.712C154.624 367.199 163.743 369.018 172.788 371.165C181.758 360.256 188.776 347.322 197.188 336.227C195.86 324.222 196.057 319.961 199.229 308.015C192.85 308.002 187.206 308.268 180.603 307.999C162.364 307.256 143.169 303.628 127.146 294.551C123.337 292.418 117.592 287.539 116.951 282.873C116.007 276.004 118.515 266.05 119.723 259.143L127.242 217.753L134.117 177.933C135.374 170.561 136.516 163.097 138.006 155.781C138.506 153.326 139.379 149.122 140.793 147.133C144.218 142.865 152.714 140.923 158.019 140.251C185.107 136.825 214.636 138.869 240.338 148.389C243.326 149.496 248.395 151.633 250.792 153.322C249.133 149.822 246.75 145.914 244.946 142.326C240.086 132.839 237.003 122.543 235.847 111.946C234.045 93.9039 239.576 75.8945 251.194 61.9731C261.067 49.7102 274.768 41.1139 290.105 37.561C295.213 36.385 299.787 35.9129 304.99 35.3894ZM289.183 227.053C296.243 231.84 299.593 234.215 295.713 243.015C297.924 248.485 297.451 251.318 292.811 255.225C294.164 261.15 292.103 262.281 288.283 266.282C287.583 267.015 287.011 268.889 286.425 269.814C282.465 275.448 273.249 275.607 267.195 275.41C254.945 289.431 235.302 297.87 216.843 299.139C214.413 299.284 211.981 299.404 209.548 299.498C205.3 312.814 199.233 325.91 206.311 339.514C218.171 362.308 255.049 375.407 277.492 385.397C282.123 387.459 289.627 390.01 292.952 393.764C296.348 397.599 298.375 404.306 300.61 409.016C302.307 412.59 304.222 416.103 306.167 419.546C314.675 434.598 325.554 448.013 334.476 462.767C338.021 468.628 339.415 475.598 343.057 481.368C344.18 483.148 345.61 484.879 347.666 485.568C352.595 487.222 362.825 481.664 367.468 479.509C374.48 476.241 401.424 464.454 403.774 457.721C404.05 456.929 404.034 456.084 403.67 455.322C403.148 454.228 402.036 453.632 400.925 453.287C390.229 449.971 368.89 459.151 361.706 456.329C359.04 455.282 357.11 452.485 355.769 450.06C352.005 443.252 349.877 435.572 347.132 428.323C343.003 417.418 338.605 406.605 334.563 395.67C332.214 389.319 330.202 382.221 326.723 376.388C325.054 373.59 322.737 371.265 320.344 369.083C314.445 363.705 307.873 359.086 301.4 354.439C295.151 349.952 288.924 345.423 282.615 341.022C278.204 337.945 272.716 335.267 268.94 331.447C267.692 330.184 266.828 328.934 267.337 327.102C267.481 326.585 267.789 326.074 268.272 325.808C269.523 325.118 271.491 325.838 272.678 326.347C274.976 327.333 277.043 328.818 279.113 330.204C285.388 317.802 291.566 305.351 297.646 292.852C301.294 285.35 304.693 277.73 307.837 270.003C315.596 251.185 322.995 230.62 317.541 210.102C314.532 209.297 317.541 210.102 314.532 209.297C312.275 207.845 307.01 205.589 306.258 204.837C299.516 200.858 297.737 200.294 291.303 195.646C287.881 193.175 281.483 187.048 278.401 185.257C279.705 191.133 281.392 192.043 283.921 197.063C288.64 206.434 289.351 216.76 289.183 227.053ZM283.104 267.207C281.031 267.117 276.442 266.891 275.297 264.864C275.628 261.018 287.307 263.995 288.297 259.267C288.458 258.493 288.288 258.541 287.888 258.014C284.896 256.589 278.165 258.621 276.902 256.126C278.083 250.708 295.633 254.436 291.444 245.68C290.738 245.471 285.741 247.126 284.316 247.284C283.019 247.428 281.883 247.56 280.496 247.626C279.694 247.428 279.142 247.396 278.588 246.803C278.213 245.973 278.168 246.001 278.324 245.062C281.035 240.648 301.562 242.407 288.279 232.293C283.683 235.541 280.314 235.621 274.898 235.515C265.285 235.328 264.749 234.217 264.528 225.233C256.9 229.636 253.684 234.193 248.742 241.196C237.078 238.471 225.346 233.992 213.242 232.26C210.521 231.871 204.308 231.61 202.872 229.471C202.349 222.815 227.225 229.564 230.717 230.528C234.612 228.616 238.325 226.689 242.547 225.35C244.218 224.821 249.573 223.771 248.133 227.603C247.153 230.211 242.8 231.744 240.264 232.67C240.088 232.735 239.91 232.798 239.731 232.857C241.936 233.682 244.147 234.49 246.364 235.281L246.512 235.124C247.796 233.735 249.407 231.398 250.628 229.868C254.924 224.479 258.108 222.51 264.373 220.174C262.234 211.414 260.222 201.515 251.622 196.381C248.63 194.617 245.186 193.773 241.718 193.953C229.271 195.666 204.947 213.787 194.639 221.235C188.274 225.833 177.609 236.391 178.799 244.916C179.271 248.299 181.649 251.575 184.524 253.515C197.253 261.565 216.057 262.397 230.704 262.832C235.363 262.97 239.719 262.945 244.293 263.274C246.315 263.42 248.946 265.675 250.888 266.577C258.181 269.961 267.463 270.947 275.417 270.174C277.928 269.93 281.038 268.523 283.104 267.207ZM104.516 391.634C112.383 387.682 118.337 389.459 126.405 392.081C138.908 396.169 150.961 401.855 163.412 406.019C173.477 409.386 185.364 413.538 195.375 408.02C210.948 399.435 223.615 386.825 235.694 374.01C223.545 367.573 211.513 360.553 203.892 348.913C203.232 347.906 200.991 344.774 200.095 344.246C193.851 352.461 188.674 361.4 182.644 369.766C180.441 372.823 177.987 376.489 175.322 379.118C164.11 376.52 152.822 374.258 141.475 372.338C136.534 371.489 131.067 371.384 126.298 370.032C118.256 367.754 116.363 361.493 107.626 359.931C99.9506 362.035 88.3118 378.893 84.291 385.944C82.2286 389.561 77.924 396.939 78.9286 401.017C79.1597 401.955 79.6776 402.77 80.5557 403.218C82.397 404.158 85.1387 403.212 86.9526 402.534C93.5368 400.072 98.3917 394.838 104.516 391.634ZM202.771 299.875C197.486 298.292 183.886 298.88 178.382 298.111C180.962 297.846 195.768 296.289 197.744 294.556L197.872 294.062C197.315 293.161 196.327 293.398 194.823 293.398C191.814 293.398 194.071 293.398 180.531 293.398C185.796 291.894 195.337 291.468 197.505 291.35C197.622 289.76 197.757 288.694 198.021 287.121C196.462 286.875 186.603 287.485 185.151 287.121C187.238 286.797 196.505 285.553 198.6 285.289C199.562 283.975 200.533 282.667 201.515 281.368C199.94 281.252 192.749 280.741 191.169 280.81C194.108 279.781 208.426 277.916 211.354 277.752L212.074 274.406C185.883 276.327 147.809 274.405 127.032 256.332C125.657 262.283 121.376 278.689 124.579 283.503C129.796 291.346 147.035 297.002 156.129 298.842C166.65 300.97 193.359 304.433 202.771 299.875ZM312.768 42.108C291.843 42.5727 274.303 47.345 259.396 62.9876C215.407 109.147 266.886 178.952 312.212 199.918C328.277 205.853 335.809 201.036 346.99 189.196C373.204 161.437 389.876 118.465 372.852 81.7247C362.729 59.8754 336.863 42.89 312.768 42.108ZM139.635 183.597C142.308 185.854 144.944 188.067 148.119 189.982C165.556 200.498 187.372 202.491 207.305 203.163C209.563 203.239 212.497 201.522 214.457 200.509C212.726 200.121 210.844 199.886 209.387 199.639C207.61 199.338 199.615 199.155 198.804 198.642L198.959 198.41C203.326 198.129 218.98 196.157 222.742 194.751C223.169 194.661 223.236 194.604 223.642 194.43C223.19 194.053 221.745 193.973 221.026 193.868C215.158 193.4 205.145 191.876 199.953 189.831C210.832 190.203 217.483 191.224 228.752 188.034C224.841 187.861 207.817 187.325 204.709 186.031L203.133 185.358C203.691 185.071 206.857 185.202 207.71 185.183C215.609 185.012 222.935 184.635 230.525 182.139C222.952 182.27 216.863 182.178 209.345 181.546C206.134 180.685 204.381 180.841 200.871 179.478C203.49 179.433 206.511 179.536 209.137 179.592C223.088 179.839 229.401 180.082 242.678 174.106C239.766 174.34 236.805 174.583 233.906 174.943C223.163 176.276 212.182 175.827 201.407 174.856C181.467 173.061 160.963 170.433 143.981 158.922C142.85 166.413 141.447 176.41 139.635 183.597ZM414.748 204.081C410.925 206.745 407.08 218.04 404.839 222.949C407.665 230.202 413.121 243.269 398.882 242.416C397.565 242.337 396.869 240.903 396.147 242.703C393.382 249.509 388.346 257.885 387.079 265.055C387.511 265.667 388.098 266.446 388.716 266.847C393.324 269.843 409.784 277.142 414.568 278.053C415.445 277.488 416.101 277.191 416.624 276.319C416.855 274.216 413.604 273.732 411.983 272.809C405.484 268.698 404.099 264.312 409.984 258.725C407.577 253.173 409.152 250.57 413.665 247.239C412.381 240.244 414.715 236.78 421.658 235.553C420.685 230.818 422.18 226.305 427.47 225.464C431.032 224.898 435.516 226.683 438.566 228.447C440.323 224.535 442.013 220.867 442.933 216.638C442.531 216.133 441.851 215.341 441.311 215.038C435.915 212.019 420.311 204.897 414.748 204.081ZM424.707 265.123C420.059 265.145 417.177 263.081 412.745 261.9C406.696 266.155 413.403 269.208 417.342 270.965C419.383 271.876 421.727 272.495 423.961 272.489C429.96 272.346 427.663 268.319 428.469 265.598C429.729 261.345 434.323 265.531 433.417 258.332L433.013 255.357C440.189 251.628 439.146 251.655 437.411 244.574C440.208 243.498 441.154 243.326 443.625 241.628C445.933 237.505 443.024 235.226 439.496 233.253C436.253 231.44 432.648 230.096 429.111 228.972C426.658 230.045 424.523 231.441 425.51 234.392C426.664 237.842 434.678 239.641 435.091 242.624C433.691 245.335 429.138 242.323 427.224 241.509C423.102 239.588 416.752 237.851 417.586 244.903C417.771 246.473 419.742 247.247 420.694 247.965C422.816 249.567 430.765 250.718 430.15 254.082C427.487 256.445 419.038 250.933 415.803 250.983C414.479 251.004 413.103 253.029 413.097 254.482C413.072 260.412 423.32 259.556 424.965 263.744C424.918 264.414 424.956 264.513 424.707 265.123ZM251.833 182.25C245.157 183.502 242.654 184.686 237.448 189.076C243.715 187.709 250.495 188.039 255.901 191.757C267.981 200.064 270.505 214.793 270.613 228.304C270.795 229.097 270.751 229.656 271.507 230.038C274.043 231.322 279.414 230.092 282.235 229.903C284.545 211.333 277.561 185.073 255.846 182.316C254.553 182.152 253.132 182.151 251.833 182.25ZM239.585 268.86C233.716 268.948 226.535 268.971 220.712 268.278C220.084 271.166 218.924 274.395 217.959 277.212C223.49 275.888 226.945 275.131 232.21 272.868C234.597 271.712 237.475 270.398 239.585 268.86ZM215.298 292.934C232.101 291.134 245.863 285.807 258.751 274.665C255.27 273.5 251.413 272.119 247.916 271.07C238.401 277.803 229.214 282.26 217.509 283.739C214.097 284.246 210.348 283.85 207.096 285.062C204.904 285.879 203.081 289.815 204.776 291.636C206.842 293.857 212.556 293.234 215.298 292.934ZM312.322 277.171C313.138 276.146 314.174 274.911 314.924 273.869C328.205 255.912 336.728 231.182 328.96 209.297L325.418 209.474C324.476 209.541 324.179 209.38 323.636 209.875C323.551 211.922 324.024 215.414 324.387 217.532C327.274 234.412 322.404 250.661 316.328 266.225C314.925 269.819 313.784 273.623 312.322 277.171ZM134.251 216.067C144.038 227.592 160.846 230.935 175.108 234.182C178.105 228.49 180.63 225.742 185.207 221.418C190.394 216.814 195.731 212.5 201.671 208.877C185.194 207.906 165.315 205.134 150.227 198.032C146.498 196.277 141.927 193.111 138.382 190.785C137.229 197.008 134.525 210.068 134.251 216.067ZM251.936 171.487C249.999 172.138 248.982 172.515 247.176 173.51C255.859 167.978 254.355 177.757 247.5 177.412C255.107 170.987 247.764 177.59 248.337 177.457C250.275 176.68 246.008 174.309 245.328 171.739C244.57 171.268 252.817 171.442 251.936 171.487ZM258.642 175.848C261.601 176.133 264.554 176.469 267.501 176.854L268.311 176.876C269.272 174.513 262.304 168.318 260.46 166.874C260.014 169.379 259.387 173.524 258.642 175.848ZM172.699 239.542C159.38 237.26 147.504 233.718 136.166 226.219C135.103 225.516 133.787 224.699 132.674 224.097C130.903 232.33 129.92 240.903 128.236 248.815C130.935 251.505 134.198 254.785 137.488 256.698C153.132 265.798 178.884 269.321 196.6 269.317C199.904 269.294 203.205 269.106 206.49 268.757C208.355 268.456 210.267 268.115 212.128 267.843C199.643 265.652 183.093 264.008 175.372 252.861C172.348 248.494 172.365 244.594 172.699 239.542ZM396.787 223.642C387.287 225.064 384.602 234.898 383.838 243.192C383.643 245.314 384.246 247.661 383.364 249.695C381 255.513 375.934 257.395 370.69 259.832C364.06 262.904 357.333 265.761 350.518 268.4C345.074 260.413 342.02 249.413 337.313 240.237C334.878 253.062 330.844 261.144 324.198 272.073C326.623 275.589 329.637 280.056 332.352 283.343C334.765 286.453 340.089 292.763 344.289 293.022C355.873 293.738 369.74 285.44 379.957 280.469C383.195 278.893 389.292 275.928 391.817 274.388C380.362 268.892 379.907 266.849 384.983 255.14C387.536 249.251 389.962 243.215 392.954 237.431C392.19 235.896 390.683 232.98 392.479 231.747C395.272 232.308 399.303 243.875 404.284 235.78C403.916 232.31 402.567 226.678 399.746 224.33C398.886 223.615 397.892 223.685 396.787 223.642ZM172.288 144.462C164.324 145.03 152.764 145.095 146.555 150.443C144.564 152.159 148.398 155.104 149.786 155.834C172.459 167.745 201.758 170.846 226.797 170.448C245.765 168.907 269.337 164.406 235.995 153.28C218.404 147.283 199.94 144.248 181.355 144.301C178.687 144.31 174.889 144.242 172.288 144.462Z",
 	"M280.894 104.377C301.437 102.81 319.985 122.188 322.827 141.584C324.007 149.64 321.169 152.105 313.663 153.1C294.419 153.245 275.02 136.893 271.448 118.056C269.987 110.35 272.979 105.566 280.894 104.377Z",
@@ -18,7 +17,6 @@ const ALIEN_PATHS = [
 	"M220.919 193.668C221.638 193.774 223.083 193.854 223.534 194.231C223.129 194.404 223.062 194.461 222.634 194.551C222.09 194.481 221.373 194.487 220.809 194.472L220.558 194.135L220.919 193.668Z",
 ];
 
-// ── Magnetic CTA ──
 function MagneticButton({
 	children,
 	href,
@@ -38,8 +36,8 @@ function MagneticButton({
 		(e: React.MouseEvent) => {
 			const rect = ref.current?.getBoundingClientRect();
 			if (!rect) return;
-			x.set((e.clientX - (rect.left + rect.width / 2)) * 0.2);
-			y.set((e.clientY - (rect.top + rect.height / 2)) * 0.2);
+			x.set((e.clientX - (rect.left + rect.width / 2)) * 0.18);
+			y.set((e.clientY - (rect.top + rect.height / 2)) * 0.18);
 		},
 		[x, y],
 	);
@@ -51,8 +49,8 @@ function MagneticButton({
 
 	const base =
 		variant === "primary"
-			? "bg-white text-[#0a0a0f] hover:bg-[#e2e2e8] shadow-[0_0_40px_rgba(255,255,255,0.08)]"
-			: "bg-white/[0.04] text-[#999] border border-white/[0.1] hover:border-white/[0.25] hover:text-white hover:bg-white/[0.06]";
+			? "bg-foreground text-background hover:bg-foreground/90"
+			: "bg-transparent text-foreground border border-border hover:border-foreground/40";
 
 	return (
 		<motion.a
@@ -61,121 +59,79 @@ function MagneticButton({
 			style={{ x: springX, y: springY }}
 			onMouseMove={handleMouse}
 			onMouseLeave={handleLeave}
-			whileTap={{ scale: 0.95 }}
-			className={`inline-flex items-center px-8 py-4 rounded-full font-semibold text-[15px] no-underline transition-all duration-300 tracking-wide ${base}`}
+			whileTap={{ scale: 0.96 }}
+			className={`inline-flex items-center justify-center min-h-[48px] px-7 py-3 rounded-full font-medium text-[15px] no-underline transition-colors duration-300 ${base}`}
 		>
 			{children}
 		</motion.a>
 	);
 }
 
-// ── Alien background — filled paths (compound paths require fill to render correctly) ──
-// The body path is compound (many internal M subpaths). Stroke-only renders
-// all internal detail lines as visible overlapping strokes. Fill hides them
-// correctly, showing only the silhouette with internal cutouts.
+// Single inlined symbol — both layers reference via <use>, no path duplication.
 function AlienBackground() {
-	const containerRef = useRef<HTMLDivElement>(null);
-	const mouseX = useMotionValue(0);
-	const mouseY = useMotionValue(0);
-
-	const springX = useSpring(mouseX, { stiffness: 40, damping: 30 });
-	const springY = useSpring(mouseY, { stiffness: 40, damping: 30 });
-
-	const layerX = useTransform(springX, [-0.5, 0.5], [-15, 15]);
-	const layerY = useTransform(springY, [-0.5, 0.5], [-10, 10]);
-	const glowX = useTransform(springX, [-0.5, 0.5], [-22, 22]);
-	const glowY = useTransform(springY, [-0.5, 0.5], [-16, 16]);
-
-	useEffect(() => {
-		const handleMove = (e: MouseEvent) => {
-			if (!containerRef.current) return;
-			const rect = containerRef.current.getBoundingClientRect();
-			mouseX.set((e.clientX - rect.left) / rect.width - 0.5);
-			mouseY.set((e.clientY - rect.top) / rect.height - 0.5);
-		};
-		window.addEventListener("mousemove", handleMove, { passive: true });
-		return () => window.removeEventListener("mousemove", handleMove);
-	}, [mouseX, mouseY]);
-
-	const svgContent = (
-		<>
-			<defs>
-				<linearGradient id="alien-fill-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-					<stop offset="0%" stopColor="#38bdf8" />
-					<stop offset="50%" stopColor="#818cf8" />
-					<stop offset="100%" stopColor="#c084fc" />
-				</linearGradient>
-			</defs>
-			{ALIEN_PATHS.map((d, i) => (
-				<path key={i} d={d} fill="url(#alien-fill-grad)" />
-			))}
-		</>
-	);
-
 	return (
 		<div
-			ref={containerRef}
 			className="absolute inset-0 flex items-center justify-center pointer-events-none overflow-hidden"
+			aria-hidden="true"
 		>
+			{/* Hidden defs */}
+			<svg width="0" height="0" className="absolute" aria-hidden="true">
+				<defs>
+					<linearGradient id="alien-fill-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+						<stop offset="0%" stopColor="hsl(var(--alien-1))" />
+						<stop offset="50%" stopColor="hsl(var(--alien-2))" />
+						<stop offset="100%" stopColor="hsl(var(--alien-3))" />
+					</linearGradient>
+					<symbol id="alien-symbol" viewBox="0 0 510 498">
+						{ALIEN_PATHS.map((d, i) => (
+							<path key={i} d={d} fill="url(#alien-fill-grad)" />
+						))}
+					</symbol>
+				</defs>
+			</svg>
+
 			{/* CSS-only energy rings */}
-			<div className="absolute w-[40%] aspect-square rounded-full border border-white/[0.04] alien-ring alien-ring-1" />
-			<div className="absolute w-[40%] aspect-square rounded-full border border-white/[0.04] alien-ring alien-ring-2" />
+			<div className="absolute w-[40%] aspect-square rounded-full border border-border alien-ring alien-ring-1" />
+			<div className="absolute w-[40%] aspect-square rounded-full border border-border alien-ring alien-ring-2" />
 
-			{/* Breathing wrapper — slow scale pulse makes the alien feel alive */}
+			{/* Breathing wrapper */}
 			<div className="alien-breathe">
-				{/* Glow layer — blurred copy behind, GPU-composited */}
-				<motion.div
-					className="absolute will-change-transform alien-fade"
-					style={{ x: glowX, y: glowY, filter: "blur(30px)" }}
-				>
-					<svg
-						viewBox="0 0 510 498"
-						className="w-[55vw] max-w-[640px] h-auto opacity-[0.14]"
-						aria-hidden="true"
-					>
-						{svgContent}
+				{/* Glow layer — blurred, GPU composited */}
+				<div className="absolute alien-fade" style={{ filter: "blur(28px)" }}>
+					<svg viewBox="0 0 510 498" className="w-[55vw] max-w-[640px] h-auto opacity-[0.16]">
+						<use href="#alien-symbol" />
 					</svg>
-				</motion.div>
+				</div>
 
-				{/* Crisp filled layer — the actual alien logo */}
-				<motion.div
-					className="absolute will-change-transform alien-fade"
-					style={{ x: layerX, y: layerY }}
-				>
-					<svg
-						viewBox="0 0 510 498"
-						className="w-[48vw] max-w-[560px] h-auto opacity-[0.1]"
-						aria-hidden="true"
-					>
-						{svgContent}
+				{/* Crisp layer */}
+				<div className="absolute alien-fade">
+					<svg viewBox="0 0 510 498" className="w-[48vw] max-w-[560px] h-auto opacity-[0.10]">
+						<use href="#alien-symbol" />
 					</svg>
-				</motion.div>
+				</div>
 			</div>
 
 			<style>{`
 				.alien-fade {
 					opacity: 0;
-					animation: alien-reveal 2s cubic-bezier(0.22, 1, 0.36, 1) 0.3s forwards;
+					animation: alien-reveal 1.6s cubic-bezier(0.22, 1, 0.36, 1) 0.3s forwards;
 				}
 				@keyframes alien-reveal {
 					0% { opacity: 0; transform: scale(0.92); }
 					100% { opacity: 1; transform: scale(1); }
 				}
-
-				/* Slow breathing scale — the alien pulses gently */
 				.alien-breathe {
 					position: absolute;
 					inset: 0;
 					display: flex;
 					align-items: center;
 					justify-content: center;
-					animation: alien-breathe 8s ease-in-out infinite;
+					animation: alien-breathe 9s ease-in-out infinite;
 				}
 				@keyframes alien-breathe {
 					0%, 100% { transform: scale(0.97); }
 					50% { transform: scale(1.03); }
 				}
-
 				@media (prefers-reduced-motion: reduce) {
 					.alien-fade { opacity: 1 !important; animation: none !important; }
 					.alien-breathe { animation: none !important; }
@@ -195,104 +151,67 @@ export const HeroSection = () => {
 
 			<div className="relative z-10 max-w-[1400px] mx-auto px-6 lg:px-10 w-full grid lg:grid-cols-[1.2fr_1fr] gap-12 lg:gap-16 items-center pt-28 pb-20 lg:pt-28 lg:pb-16">
 				<div className="text-center lg:text-left flex flex-col items-center lg:items-start">
-					{/* Badge — delay 0.1 */}
 					<motion.div
 						initial={{ opacity: 0, y: 12, filter: "blur(6px)" }}
 						animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
 						transition={{ duration: 0.5, delay: 0.1, ease: [0.22, 1, 0.36, 1] }}
-						className="inline-flex items-center gap-2.5 bg-white/[0.04] text-[#94a3b8] px-5 py-2.5 rounded-full text-[13px] font-medium mb-10 border border-white/[0.06] backdrop-blur-md"
+						className="inline-flex items-center gap-2.5 bg-card/60 text-muted-foreground px-4 py-2 rounded-full text-[13px] font-medium mb-10 border border-border"
 					>
-						<span className="w-1.5 h-1.5 rounded-full bg-[#38bdf8] glow-pulse" />
-						Open Source Mobile Database Client
+						<span className="w-1.5 h-1.5 rounded-full bg-[hsl(var(--alien-1))] glow-pulse" />
+						Open source · Mobile database client
 					</motion.div>
 
-					{/* Heading — delay 0.22, 0.34 */}
-					<h1 className="text-[clamp(2.8rem,8vw,6rem)] leading-[1.15] mb-8 font-black tracking-[-0.04em]">
+					<h1 className="text-[clamp(2.8rem,8vw,6rem)] leading-[1.05] mb-8 font-black tracking-[-0.04em] text-foreground">
 						<motion.span
-							className="block text-white"
+							className="block"
 							initial={{ opacity: 0, y: 32, filter: "blur(8px)" }}
 							animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-							transition={{
-								duration: 0.7,
-								delay: 0.22,
-								ease: [0.22, 1, 0.36, 1],
-							}}
+							transition={{ duration: 0.7, delay: 0.22, ease: [0.22, 1, 0.36, 1] }}
 						>
 							Your databases.
 						</motion.span>
-						{/* pb-[0.1em] prevents bg-clip-text from clipping descenders (y, g, p) */}
 						<motion.span
-							className="block bg-gradient-to-r from-white via-[#94a3b8] to-[#64748b] bg-clip-text text-transparent pb-[0.1em]"
+							className="block font-display font-normal text-foreground/95 pb-[0.1em]"
 							initial={{ opacity: 0, y: 32, filter: "blur(8px)" }}
 							animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-							transition={{
-								duration: 0.7,
-								delay: 0.34,
-								ease: [0.22, 1, 0.36, 1],
-							}}
+							transition={{ duration: 0.7, delay: 0.34, ease: [0.22, 1, 0.36, 1] }}
 						>
 							Everywhere.
 						</motion.span>
 					</h1>
 
-					{/* Subheading — delay 0.46 */}
 					<motion.p
 						initial={{ opacity: 0, y: 16, filter: "blur(4px)" }}
 						animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
 						transition={{ duration: 0.6, delay: 0.46, ease: [0.22, 1, 0.36, 1] }}
-						className="text-[clamp(1rem,2.2vw,1.25rem)] text-[#64748b] max-w-[500px] mx-auto lg:mx-0 mb-12 leading-[1.7] font-normal"
+						className="text-[clamp(1rem,2.2vw,1.2rem)] text-muted-foreground max-w-[520px] mx-auto lg:mx-0 mb-12 leading-[1.6]"
 					>
-						Connect directly to PostgreSQL, MySQL, MongoDB & more. Execute queries and visualize
-						results with native performance — all from your phone.
+						Connect directly to PostgreSQL, MySQL, MongoDB and more. Run queries and read results
+						from your phone, with native speed and no proxy in between.
 					</motion.p>
 
-					{/* CTAs — delay 0.58 */}
 					<motion.div
 						initial={{ opacity: 0, y: 16, filter: "blur(4px)" }}
 						animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
 						transition={{ duration: 0.5, delay: 0.58, ease: [0.22, 1, 0.36, 1] }}
-						className="flex flex-wrap gap-4 justify-center lg:justify-start"
+						className="flex flex-wrap gap-3 justify-center lg:justify-start"
 					>
 						<MagneticButton href="https://github.com/arioberek/COSMQ" variant="primary">
 							View on GitHub
 						</MagneticButton>
 						<MagneticButton href="#features" variant="secondary">
-							Learn More
+							How it works
 						</MagneticButton>
-					</motion.div>
-
-					{/* Stats — delay 0.7 */}
-					<motion.div
-						initial={{ opacity: 0 }}
-						animate={{ opacity: 1 }}
-						transition={{ duration: 0.8, delay: 0.7 }}
-						className="flex gap-10 mt-16 pt-8 border-t border-white/[0.06]"
-					>
-						{[
-							{ value: "6+", label: "Databases" },
-							{ value: "TCP", label: "Direct Conn" },
-							{ value: "E2E", label: "Encrypted" },
-						].map((stat) => (
-							<div key={stat.label} className="text-center lg:text-left">
-								<div className="text-white text-2xl font-black tracking-tight font-['JetBrains_Mono',monospace]">
-									{stat.value}
-								</div>
-								<div className="text-[#475569] text-[11px] tracking-[0.15em] uppercase mt-1.5 font-medium">
-									{stat.label}
-								</div>
-							</div>
-						))}
 					</motion.div>
 				</div>
 
-				{/* Phone */}
 				<div className="flex justify-center lg:justify-end">
 					<PhoneMockup />
 				</div>
 			</div>
 
-			{/* Bottom fade */}
-			<div className="absolute bottom-0 left-0 right-0 h-40 bg-gradient-to-t from-[#06060a] to-transparent pointer-events-none z-20" />
+			{/* Bottom fade into next section */}
+			<div className="absolute bottom-0 left-0 right-0 h-40 bg-gradient-to-t from-background to-transparent pointer-events-none z-20" />
 		</section>
 	);
 };

--- a/apps/landing/src/components/phone-mockup.tsx
+++ b/apps/landing/src/components/phone-mockup.tsx
@@ -1,4 +1,5 @@
 import { motion } from "motion/react";
+import phoneScreenshot from "@/assets/screenshots/app/1.jpeg";
 import { Iphone } from "./ui/iphone";
 
 export function PhoneMockup() {
@@ -21,12 +22,10 @@ export function PhoneMockup() {
 					ease: "easeInOut",
 				}}
 			>
-				{/* Raw image from public/ — bypasses Astro's image optimization pipeline */}
-				<Iphone src="/screenshots/1.jpeg" className="dark" />
+				<Iphone src={phoneScreenshot.src} />
 			</motion.div>
 
-			{/* Shadow + glow — outside any transform stack for perf */}
-			<div className="absolute -bottom-6 left-[10%] right-[10%] h-[40px] bg-[radial-gradient(ellipse,rgba(56,189,248,0.12)_0%,transparent_70%)] blur-xl pointer-events-none" />
+			<div className="absolute -bottom-6 left-[10%] right-[10%] h-[40px] bg-[radial-gradient(ellipse,hsl(var(--alien-1)/0.12)_0%,transparent_70%)] blur-xl pointer-events-none" />
 			<div className="absolute -bottom-4 left-[5%] right-[5%] h-[30px] bg-[radial-gradient(ellipse,rgba(0,0,0,0.4)_0%,transparent_70%)] blur-lg pointer-events-none" />
 		</motion.div>
 	);

--- a/apps/landing/src/components/screenshots-section.tsx
+++ b/apps/landing/src/components/screenshots-section.tsx
@@ -13,11 +13,13 @@ interface Screenshot {
 }
 
 const screenshots: Screenshot[] = [
-	{ src: Screenshot1, alt: "COSMQ - Connection List", label: "Connections" },
-	{ src: Screenshot2, alt: "COSMQ - New Connection", label: "Add Database" },
-	{ src: Screenshot3, alt: "COSMQ - Query Editor", label: "Write Queries" },
-	{ src: Screenshot4, alt: "COSMQ - Results View", label: "View Results" },
+	{ src: Screenshot1, alt: "COSMQ — Connection list", label: "Connections" },
+	{ src: Screenshot2, alt: "COSMQ — New connection", label: "Add database" },
+	{ src: Screenshot3, alt: "COSMQ — Query editor", label: "Write queries" },
+	{ src: Screenshot4, alt: "COSMQ — Results view", label: "Read results" },
 ];
+
+const PARALLAX_OFFSETS = [40, 20, 60, 30] as const;
 
 export function ScreenshotsSection() {
 	const [selectedImage, setSelectedImage] = useState<Screenshot | null>(null);
@@ -73,43 +75,39 @@ export function ScreenshotsSection() {
 		};
 	}, [selectedImage, closeModal]);
 
-	// Parallax offsets for each card
 	const offsets = [
-		useTransform(scrollYProgress, [0, 1], [40, -40]),
-		useTransform(scrollYProgress, [0, 1], [20, -20]),
-		useTransform(scrollYProgress, [0, 1], [60, -60]),
-		useTransform(scrollYProgress, [0, 1], [30, -30]),
+		useTransform(scrollYProgress, [0, 1], [PARALLAX_OFFSETS[0], -PARALLAX_OFFSETS[0]]),
+		useTransform(scrollYProgress, [0, 1], [PARALLAX_OFFSETS[1], -PARALLAX_OFFSETS[1]]),
+		useTransform(scrollYProgress, [0, 1], [PARALLAX_OFFSETS[2], -PARALLAX_OFFSETS[2]]),
+		useTransform(scrollYProgress, [0, 1], [PARALLAX_OFFSETS[3], -PARALLAX_OFFSETS[3]]),
 	];
 
 	return (
-		<section ref={sectionRef} className="relative py-32 px-6 lg:px-10 overflow-hidden">
-			{/* Section bg accent */}
-			<div className="absolute inset-0 bg-gradient-to-b from-transparent via-[#7c5cff]/[0.02] to-transparent pointer-events-none" />
-
-			<div className="relative max-w-[1400px] mx-auto">
-				{/* Header */}
+		<section ref={sectionRef} className="relative py-24 md:py-32 px-6 lg:px-10 overflow-hidden">
+			<div className="relative max-w-[1280px] mx-auto">
 				<div className="text-center mb-16">
 					<motion.span
 						initial={{ opacity: 0 }}
 						whileInView={{ opacity: 1 }}
 						viewport={{ once: true }}
-						className="inline-block text-[11px] font-mono uppercase tracking-[0.3em] text-[#555] mb-5"
+						className="eyebrow mb-6"
 					>
-						Preview
+						<span className="eyebrow-num">02</span>
+						<span className="eyebrow-rule" />
+						<span>Inside</span>
 					</motion.span>
 					<motion.h2
-						initial={{ opacity: 0, y: 20 }}
+						initial={{ opacity: 0, y: 16 }}
 						whileInView={{ opacity: 1, y: 0 }}
 						viewport={{ once: true }}
 						transition={{ duration: 0.6, delay: 0.1 }}
-						className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] text-white"
+						className="text-[clamp(2rem,5vw,3.25rem)] font-bold tracking-[-0.03em] leading-[1.1] text-foreground"
 					>
-						See it in action
+						What it <span className="font-display font-normal">looks like.</span>
 					</motion.h2>
 				</div>
 
-				{/* Screenshot grid with parallax */}
-				<div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-5">
+				<div className="grid grid-cols-2 lg:grid-cols-4 gap-4 md:gap-5 max-w-[1080px] mx-auto">
 					{screenshots.map((screenshot, i) => (
 						<motion.button
 							key={screenshot.label}
@@ -117,22 +115,22 @@ export function ScreenshotsSection() {
 							className="relative cursor-zoom-in group"
 							aria-label={`View ${screenshot.label} screenshot`}
 							style={{ y: offsets[i] }}
-							initial={{ opacity: 0, y: 40 }}
+							initial={{ opacity: 0, y: 32 }}
 							whileInView={{ opacity: 1, y: 0 }}
 							viewport={{ once: true }}
 							transition={{
 								duration: 0.6,
-								delay: i * 0.1,
-								ease: [0.25, 0.46, 0.45, 0.94],
+								delay: i * 0.08,
+								ease: [0.22, 1, 0.36, 1],
 							}}
-							whileHover={{ scale: 1.03 }}
+							whileHover={{ scale: 1.02 }}
 							whileTap={{ scale: 0.98 }}
 							onClick={(e) => {
 								triggerRef.current = e.currentTarget as HTMLButtonElement;
 								setSelectedImage(screenshot);
 							}}
 						>
-							<div className="rounded-2xl overflow-hidden border border-white/[0.05] bg-[#0c0c12] shadow-[0_20px_60px_rgba(0,0,0,0.5)] group-hover:border-white/[0.1] group-hover:shadow-[0_20px_60px_rgba(124,92,255,0.1)] transition-all duration-500">
+							<div className="rounded-2xl overflow-hidden border border-border bg-card shadow-[0_20px_60px_rgba(0,0,0,0.5)] group-hover:border-foreground/15 transition-colors duration-500">
 								<img
 									src={screenshot.src.src}
 									width={screenshot.src.width}
@@ -142,7 +140,7 @@ export function ScreenshotsSection() {
 									loading="lazy"
 								/>
 							</div>
-							<div className="mt-3 text-[12px] text-[#555] font-medium tracking-wider uppercase text-center group-hover:text-[#888] transition-colors duration-300">
+							<div className="mt-3 text-[12px] text-muted-foreground font-mono tracking-[0.12em] uppercase text-center group-hover:text-foreground transition-colors duration-300">
 								{screenshot.label}
 							</div>
 						</motion.button>
@@ -150,13 +148,12 @@ export function ScreenshotsSection() {
 				</div>
 			</div>
 
-			{/* Lightbox modal */}
 			<AnimatePresence>
 				{selectedImage && (
 					<motion.div
 						ref={modalRef}
-						className="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-md"
-						style={{ background: "rgba(6,6,10,0.92)" }}
+						className="fixed inset-0 z-50 flex items-center justify-center p-4"
+						style={{ background: "hsl(var(--background) / 0.94)" }}
 						role="dialog"
 						aria-modal="true"
 						aria-label={selectedImage.alt}
@@ -168,26 +165,26 @@ export function ScreenshotsSection() {
 					>
 						<motion.div
 							className="relative"
-							initial={{ scale: 0.85, opacity: 0 }}
+							initial={{ scale: 0.9, opacity: 0 }}
 							animate={{ scale: 1, opacity: 1 }}
-							exit={{ scale: 0.9, opacity: 0 }}
+							exit={{ scale: 0.92, opacity: 0 }}
 							transition={{ type: "spring", stiffness: 400, damping: 30 }}
 							onClick={(e) => e.stopPropagation()}
 						>
 							<button
 								type="button"
-								className="absolute -top-12 right-0 text-[#555] hover:text-white transition-colors p-1"
+								className="absolute -top-14 right-0 inline-flex items-center justify-center w-11 h-11 rounded-full text-muted-foreground hover:text-foreground hover:bg-card transition-colors"
 								onClick={closeModal}
 								aria-label="Close modal"
 							>
 								<svg
 									xmlns="http://www.w3.org/2000/svg"
-									width="24"
-									height="24"
+									width="20"
+									height="20"
 									viewBox="0 0 24 24"
 									fill="none"
 									stroke="currentColor"
-									strokeWidth="1.5"
+									strokeWidth="1.6"
 									strokeLinecap="round"
 									strokeLinejoin="round"
 									aria-hidden="true"
@@ -201,7 +198,7 @@ export function ScreenshotsSection() {
 								width={selectedImage.src.width}
 								height={selectedImage.src.height}
 								alt={selectedImage.alt}
-								className="max-h-[80vh] w-auto rounded-2xl border border-white/[0.06] shadow-[0_20px_60px_rgba(0,0,0,0.6)]"
+								className="max-h-[80vh] w-auto rounded-2xl border border-border shadow-[0_20px_60px_rgba(0,0,0,0.6)]"
 							/>
 						</motion.div>
 					</motion.div>

--- a/apps/landing/src/layouts/Layout.astro
+++ b/apps/landing/src/layouts/Layout.astro
@@ -1,22 +1,24 @@
 ---
 import AlienIcon from '../assets/logos/alien.svg';
+import '@fontsource-variable/geist/index.css';
+import '@fontsource-variable/geist-mono/index.css';
+import '@fontsource/instrument-serif/400.css';
+import '@fontsource/instrument-serif/400-italic.css';
 import '../styles/global.css';
 ---
 <!doctype html>
-<html lang="en" class="scroll-smooth">
+<html lang="en" class="dark scroll-smooth">
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
+		<meta name="theme-color" content="#06060a" />
 		<link rel="icon" type="image/svg+xml" href={AlienIcon.src} />
 		<meta name="generator" content={Astro.generator} />
-		<meta name="description" content="COSMQ - Universal mobile database client for iOS and Android. Connect directly to PostgreSQL, MySQL, and more." />
-		<title>COSMQ - Mobile Database Client</title>
-		<link rel="preconnect" href="https://fonts.googleapis.com">
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-		<link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+		<meta name="description" content="COSMQ — universal mobile database client. PostgreSQL, MySQL, MongoDB and more, direct from your phone." />
+		<title>COSMQ — Mobile Database Client</title>
 	</head>
-	<body class="m-0 w-full min-h-screen flex flex-col bg-[#06060a] text-[#f0f0f5] font-['Inter',system-ui,sans-serif] film-grain">
-		<a href="#main" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[200] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-[#7c5cff] focus:text-white focus:text-sm focus:font-medium focus:outline-none">
+	<body class="m-0 w-full min-h-screen flex flex-col bg-background text-foreground font-sans film-grain">
+		<a href="#main" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[200] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-accent focus:text-accent-foreground focus:text-sm focus:font-medium focus:outline-none">
 			Skip to content
 		</a>
 		<slot />
@@ -25,6 +27,9 @@ import '../styles/global.css';
 
 <style is:global>
 	code, pre {
-		font-family: 'JetBrains Mono', monospace;
+		font-family: var(--font-mono);
+	}
+	html {
+		font-feature-settings: "ss01", "cv11";
 	}
 </style>

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -10,20 +10,20 @@ import { Image } from 'astro:assets';
 ---
 
 <Layout>
-	<header class="fixed top-0 left-0 right-0 z-[100] backdrop-blur-[20px] border-b border-white/[0.04]" style="background: rgba(6,6,10,0.6);">
-		<nav class="max-w-[1400px] mx-auto px-6 lg:px-10 py-4 flex justify-between items-center">
-			<a href="/" class="items-center no-underline group">
+	<header class="fixed top-0 left-0 right-0 z-[100] border-b border-border bg-background/85">
+		<nav class="max-w-[1400px] mx-auto px-6 lg:px-10 h-16 flex justify-between items-center">
+			<a href="/" class="inline-flex items-center min-h-11 no-underline group">
 				<Image src={AlienLogo} alt="COSMQ" width={28} height={28} class="md:hidden block opacity-90 group-hover:opacity-100 transition-opacity" />
 				<Image src={TextLogo} alt="COSMQ" class="h-7 w-auto opacity-90 hidden md:block group-hover:opacity-100 transition-opacity" />
 			</a>
-			<div class="flex gap-3 md:gap-6 items-center">
-				<a href="#features" class="text-[#64748b] no-underline text-[13px] font-medium tracking-wide uppercase transition-colors duration-300 hover:text-white">Features</a>
-				<a href="https://github.com/arioberek/COSMQ" class="text-[#f0f0f5] no-underline text-[13px] font-semibold tracking-wide px-5 py-2.5 rounded-full bg-white/[0.06] border border-white/[0.08] hover:bg-white/[0.12] hover:border-white/[0.15] transition-all duration-300">GitHub</a>
+			<div class="flex gap-1 md:gap-2 items-center">
+				<a href="#features" class="inline-flex items-center min-h-11 px-3 text-muted-foreground no-underline text-[13px] font-medium tracking-wide uppercase transition-colors duration-300 hover:text-foreground">Features</a>
+				<a href="https://github.com/arioberek/COSMQ" class="inline-flex items-center min-h-11 px-5 text-foreground no-underline text-[13px] font-semibold tracking-wide rounded-full bg-card border border-border hover:bg-secondary hover:border-foreground/20 transition-colors duration-300">GitHub</a>
 			</div>
 		</nav>
 	</header>
 	<main id="main" class="w-full overflow-x-hidden">
-		<HeroSection client:load />
+		<HeroSection client:idle />
 
 		<FeaturesSection client:visible />
 
@@ -31,17 +31,17 @@ import { Image } from 'astro:assets';
 
 		<DatabaseMarquee client:visible />
 
-		<footer class="relative py-20 px-6 border-t border-white/[0.04]">
+		<footer class="relative py-16 px-6 border-t border-border">
 			<div class="max-w-[1400px] mx-auto flex flex-col md:flex-row items-center justify-between gap-6">
 				<div class="flex items-center gap-3">
-					<Image src={AlienLogo} alt="" width={22} height={22} class="opacity-40" aria-hidden="true" />
-					<p class="m-0 text-[#555] text-sm tracking-wide">&copy; {new Date().getFullYear()} COSMQ · Built by <a href="https://arielton.com" class="text-[#777] no-underline hover:text-white transition-colors duration-300">Arielton Oberek</a></p>
+					<Image src={AlienLogo} alt="" width={22} height={22} class="opacity-50" aria-hidden="true" />
+					<p class="m-0 text-muted-foreground text-sm tracking-wide">&copy; {new Date().getFullYear()} COSMQ · Built by <a href="https://arielton.com" class="inline-flex items-center min-h-11 text-foreground no-underline hover:text-foreground/80 transition-colors duration-300">Arielton Oberek</a></p>
 				</div>
 				<nav aria-label="Footer">
-					<ul class="flex gap-8 list-none m-0 p-0">
-						<li><a href="https://github.com/arioberek/COSMQ" class="text-[#555] no-underline text-[13px] tracking-wide hover:text-white transition-colors duration-300">GitHub</a></li>
-						<li><a href="https://github.com/arioberek/COSMQ/blob/main/LICENSE" class="text-[#555] no-underline text-[13px] tracking-wide hover:text-white transition-colors duration-300">License</a></li>
-						<li><a href="https://github.com/arioberek/COSMQ/issues" class="text-[#555] no-underline text-[13px] tracking-wide hover:text-white transition-colors duration-300">Issues</a></li>
+					<ul class="flex flex-wrap gap-2 md:gap-4 list-none m-0 p-0 justify-center">
+						<li><a href="https://github.com/arioberek/COSMQ" class="inline-flex items-center min-h-11 px-3 text-muted-foreground no-underline text-[13px] tracking-wide hover:text-foreground transition-colors duration-300">GitHub</a></li>
+						<li><a href="https://github.com/arioberek/COSMQ/blob/main/LICENSE" class="inline-flex items-center min-h-11 px-3 text-muted-foreground no-underline text-[13px] tracking-wide hover:text-foreground transition-colors duration-300">License</a></li>
+						<li><a href="https://github.com/arioberek/COSMQ/issues" class="inline-flex items-center min-h-11 px-3 text-muted-foreground no-underline text-[13px] tracking-wide hover:text-foreground transition-colors duration-300">Issues</a></li>
 					</ul>
 				</nav>
 			</div>

--- a/apps/landing/src/styles/global.css
+++ b/apps/landing/src/styles/global.css
@@ -4,57 +4,44 @@
 
 @layer base {
 	:root {
-		--background: 0 0% 100%;
-		--foreground: 0 0% 3.9%;
-		--card: 0 0% 100%;
-		--card-foreground: 0 0% 3.9%;
-		--popover: 0 0% 100%;
-		--popover-foreground: 0 0% 3.9%;
-		--primary: 0 0% 9%;
-		--primary-foreground: 0 0% 98%;
-		--secondary: 0 0% 96.1%;
-		--secondary-foreground: 0 0% 9%;
-		--muted: 0 0% 96.1%;
-		--muted-foreground: 0 0% 45.1%;
-		--accent: 0 0% 96.1%;
-		--accent-foreground: 0 0% 9%;
-		--destructive: 0 84.2% 60.2%;
+		/* Committed dark palette — no light theme */
+		--background: 240 14% 4%;
+		--foreground: 240 20% 95%;
+		--card: 240 14% 6%;
+		--card-foreground: 240 20% 95%;
+		--popover: 240 14% 6%;
+		--popover-foreground: 240 20% 95%;
+		--primary: 240 20% 95%;
+		--primary-foreground: 240 14% 4%;
+		--secondary: 240 10% 10%;
+		--secondary-foreground: 240 20% 95%;
+		--muted: 240 10% 10%;
+		--muted-foreground: 220 9% 65%;
+		--accent: 252 100% 68%;
+		--accent-foreground: 0 0% 100%;
+		--destructive: 0 62% 30%;
 		--destructive-foreground: 0 0% 98%;
-		--border: 0 0% 89.8%;
-		--input: 0 0% 89.8%;
-		--ring: 0 0% 3.9%;
+		--border: 240 10% 14%;
+		--input: 240 10% 14%;
+		--ring: 252 100% 68%;
 		--chart-1: 12 76% 61%;
 		--chart-2: 173 58% 39%;
 		--chart-3: 197 37% 24%;
 		--chart-4: 43 74% 66%;
 		--chart-5: 27 87% 67%;
-		--radius: 0.5rem;
-	}
-	.dark {
-		--background: 0 0% 3.9%;
-		--foreground: 0 0% 98%;
-		--card: 0 0% 3.9%;
-		--card-foreground: 0 0% 98%;
-		--popover: 0 0% 3.9%;
-		--popover-foreground: 0 0% 98%;
-		--primary: 0 0% 98%;
-		--primary-foreground: 0 0% 9%;
-		--secondary: 0 0% 14.9%;
-		--secondary-foreground: 0 0% 98%;
-		--muted: 0 0% 14.9%;
-		--muted-foreground: 0 0% 63.9%;
-		--accent: 0 0% 14.9%;
-		--accent-foreground: 0 0% 98%;
-		--destructive: 0 62.8% 30.6%;
-		--destructive-foreground: 0 0% 98%;
-		--border: 0 0% 14.9%;
-		--input: 0 0% 14.9%;
-		--ring: 0 0% 83.1%;
-		--chart-1: 220 70% 50%;
-		--chart-2: 160 60% 45%;
-		--chart-3: 30 80% 55%;
-		--chart-4: 280 65% 60%;
-		--chart-5: 340 75% 55%;
+		--radius: 0.75rem;
+
+		--surface-1: 240 12% 7%;
+		--surface-2: 240 12% 10%;
+		--rule: 240 8% 18%;
+
+		--alien-1: 199 89% 60%;
+		--alien-2: 234 89% 74%;
+		--alien-3: 270 95% 75%;
+
+		--font-sans: "Geist Variable", "Geist", system-ui, sans-serif;
+		--font-serif: "Instrument Serif", Georgia, serif;
+		--font-mono: "Geist Mono Variable", "Geist Mono", ui-monospace, monospace;
 	}
 }
 
@@ -62,12 +49,19 @@
 	* {
 		@apply border-border;
 	}
+	html {
+		font-family: var(--font-sans);
+	}
 	body {
 		@apply bg-background text-foreground;
 	}
 
+	#main {
+		scroll-margin-top: 5rem;
+	}
+
 	:focus-visible {
-		outline: 2px solid #38bdf8;
+		outline: 2px solid hsl(var(--ring));
 		outline-offset: 2px;
 		border-radius: 4px;
 	}
@@ -84,33 +78,15 @@
 	}
 }
 
-/* ── Aurora background — cool tones, subtle ── */
-@keyframes aurora-shift {
-	0%,
-	100% {
-		background-position: 0% 50%;
-	}
-	25% {
-		background-position: 100% 0%;
-	}
-	50% {
-		background-position: 100% 100%;
-	}
-	75% {
-		background-position: 0% 100%;
-	}
-}
-
+/* ── Static aurora — no animation, no paint cost ── */
 .aurora-bg {
 	background:
-		radial-gradient(ellipse 80% 60% at 20% 40%, rgba(56, 189, 248, 0.07) 0%, transparent 60%),
-		radial-gradient(ellipse 60% 80% at 80% 20%, rgba(129, 140, 248, 0.06) 0%, transparent 60%),
-		radial-gradient(ellipse 70% 50% at 50% 80%, rgba(6, 182, 212, 0.05) 0%, transparent 60%);
-	background-size: 200% 200%;
-	animation: aurora-shift 25s ease-in-out infinite;
+		radial-gradient(ellipse 80% 60% at 20% 40%, hsl(var(--alien-1) / 0.05) 0%, transparent 60%),
+		radial-gradient(ellipse 60% 80% at 80% 20%, hsl(var(--alien-2) / 0.05) 0%, transparent 60%),
+		radial-gradient(ellipse 70% 50% at 50% 80%, hsl(var(--alien-3) / 0.04) 0%, transparent 60%);
 }
 
-/* ── Film grain — smaller element, lower cost ── */
+/* ── Film grain — small, fixed, GPU-cheap ── */
 @keyframes grain {
 	0%,
 	100% {
@@ -140,7 +116,7 @@
 	width: 200%;
 	height: 200%;
 	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
-	opacity: 0.025;
+	opacity: 0.022;
 	pointer-events: none;
 	z-index: 9999;
 	animation: grain 6s steps(6) infinite;
@@ -149,12 +125,12 @@
 /* ── Grid pattern ── */
 .grid-pattern {
 	background-image:
-		linear-gradient(rgba(255, 255, 255, 0.015) 1px, transparent 1px),
-		linear-gradient(90deg, rgba(255, 255, 255, 0.015) 1px, transparent 1px);
+		linear-gradient(hsl(var(--foreground) / 0.012) 1px, transparent 1px),
+		linear-gradient(90deg, hsl(var(--foreground) / 0.012) 1px, transparent 1px);
 	background-size: 60px 60px;
 }
 
-/* ── Glow pulse ── */
+/* ── Pulse dot ── */
 @keyframes glow-pulse {
 	0%,
 	100% {
@@ -164,26 +140,24 @@
 		opacity: 0.9;
 	}
 }
-
 .glow-pulse {
 	animation: glow-pulse 3s ease-in-out infinite;
 }
 
-/* ── Alien energy rings — pure CSS, no JS ── */
+/* ── Alien rings ── */
 @keyframes ring-expand {
 	0% {
 		opacity: 0;
 		transform: scale(0.3);
 	}
 	30% {
-		opacity: 0.08;
+		opacity: 0.06;
 	}
 	100% {
 		opacity: 0;
 		transform: scale(2);
 	}
 }
-
 .alien-ring {
 	will-change: transform, opacity;
 }
@@ -194,7 +168,35 @@
 	animation: ring-expand 6s ease-out 3s infinite;
 }
 
-/* ── Scrollbar — neutral ── */
+/* ── Editorial display face — used sparingly ── */
+.font-display {
+	font-family: var(--font-serif);
+	font-style: italic;
+	font-weight: 400;
+	letter-spacing: -0.02em;
+}
+
+/* ── Section eyebrow ── */
+.eyebrow {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.75rem;
+	font-family: var(--font-mono);
+	font-size: 11px;
+	letter-spacing: 0.18em;
+	text-transform: uppercase;
+	color: hsl(var(--muted-foreground));
+}
+.eyebrow .eyebrow-num {
+	color: hsl(var(--foreground) / 0.5);
+}
+.eyebrow .eyebrow-rule {
+	width: 28px;
+	height: 1px;
+	background: hsl(var(--rule));
+}
+
+/* ── Scrollbar ── */
 ::-webkit-scrollbar {
 	width: 6px;
 }
@@ -202,9 +204,9 @@
 	background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-	background: rgba(148, 163, 184, 0.2);
+	background: hsl(var(--muted-foreground) / 0.25);
 	border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-	background: rgba(148, 163, 184, 0.35);
+	background: hsl(var(--muted-foreground) / 0.4);
 }

--- a/apps/landing/tailwind.config.js
+++ b/apps/landing/tailwind.config.js
@@ -4,6 +4,11 @@ export default {
 	content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
 	theme: {
 		extend: {
+			fontFamily: {
+				sans: ['"Geist Variable"', "Geist", "system-ui", "sans-serif"],
+				mono: ['"Geist Mono Variable"', '"Geist Mono"', "ui-monospace", "monospace"],
+				display: ['"Instrument Serif"', "Georgia", "serif"],
+			},
 			borderRadius: {
 				lg: "var(--radius)",
 				md: "calc(var(--radius) - 2px)",

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,9 @@
       "dependencies": {
         "@astrojs/cloudflare": "^12.6.12",
         "@astrojs/react": "^4.4.2",
+        "@fontsource-variable/geist": "^5.2.8",
+        "@fontsource-variable/geist-mono": "^5.2.7",
+        "@fontsource/instrument-serif": "^5.2.8",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "astro": "^5.16.6",
@@ -43,7 +46,7 @@
     },
     "apps/mobile": {
       "name": "@cosmq/mobile",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@expo/vector-icons": "^15",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -521,6 +524,12 @@
     "@floating-ui/react-native": ["@floating-ui/react-native@0.10.7", "", { "dependencies": { "@floating-ui/core": "^1.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-native": ">=0.64.0" } }, "sha512-deSecLPrdfl8RL1yyNJlbgqDDZFPuhBtJhY2aTnOZOoJWaal2vVOad9EBVIa0QV/YordgTyFPgDI8oLfyLZuZA=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "@fontsource-variable/geist": ["@fontsource-variable/geist@5.2.8", "", {}, "sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw=="],
+
+    "@fontsource-variable/geist-mono": ["@fontsource-variable/geist-mono@5.2.7", "", {}, "sha512-ZKlZ5sjtalb2TwXKs400mAGDlt/+2ENLNySPx0wTz3bP3mWARCsUW+rpxzZc7e05d2qGch70pItt3K4qttbIYA=="],
+
+    "@fontsource/instrument-serif": ["@fontsource/instrument-serif@5.2.8", "", {}, "sha512-s+bkz+syj2rO00Rmq9g0P+PwuLig33DR1xDR8pTWmovH1pUjwnncrFk++q9mmOex8fUQ7oW80gPpPDaw7V1MMw=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 


### PR DESCRIPTION
## Summary

Reshapes the landing page from AI-template SaaS layout into a more distinctive editorial dark-mode experience. Verified at runtime via agent-browser: `Geist Variable` and `Geist Mono Variable` report `loaded`, computed `font-family` on `body`/`h1`/`h2` resolves to Geist.

### Typography
- Self-host **Geist** + **Geist Mono** via `@fontsource-variable`; pair with **Instrument Serif** italic as a sparingly-used display accent (`.font-display`)
- Replaces Inter and JetBrains Mono (Google Fonts CDN dropped → no cache/CDN ambiguity)
- Tailwind `font-sans` / `font-mono` / `font-display` utilities map to the variable families

### Theming
- Routes every color through `hsl(var(--*))` shadcn-style tokens
- Committed dark-only palette (no light theme)
- Muted text lifted from `#555` / `#475569` / `#666` (~2.6–3.9:1, fails WCAG AA) to `#9ca3af` (~6.5:1, passes AA)

### Hero
- Drop the gradient `bg-clip-text` headline and the `6+ / TCP / E2E` stats strip (classic AI tells)
- Italic Instrument Serif on "Everywhere." instead of a tri-stop gradient
- Dedupe the ~9 KB `ALIEN_PATHS` string via `<symbol>` + `<use>` (renders once instead of twice)
- `client:idle` instead of `client:load`

### Features
- Replace 2×2 numbered card grid with an editorial vertical list (12-col grid, top rule per row, `num · icon · title · description`)
- Single `whileInView` animation per row instead of per-card `useScroll` listeners
- Drop translucent giant numerals and hover gradient

### Screenshots
- Modal close button is now a 44×44 button
- Label color uses `text-muted-foreground`
- Grid is `grid-cols-2 lg:grid-cols-4` (was `md:grid-cols-4`) so phones aren't cramped at tablet widths

### Database section
- Rewritten as an actual horizontal scrolling **marquee** (component name finally matches behavior)
- Edge-fade mask, pause-on-hover, `prefers-reduced-motion` respect
- 44px / 52px icon tiles with explicit `width`/`height` so they can't squish

### Header & misc
- Drop the 20px navbar `backdrop-blur` (AI tell + composite cost)
- 44px tap targets on nav pill, footer links, modal close
- Aurora is static layered gradient (no `background-position` animation)
- Numbered editorial eyebrows (`01 — Why it works`, `02 — Inside`, `03 — Databases`) replace three identical uppercase labels
- Tightened section copy away from SaaS clichés

### Files
12 changed: 353 insertions, 487 deletions

## Test plan
- [ ] `bun run --cwd apps/landing build` succeeds
- [ ] Open `https://cosmq.localhost:1355` (via `portless --app-port 4321 cosmq bun run dev`) and hard-refresh
- [ ] DevTools → Network → `font` filter shows `geist-latin-wght-normal.*.woff2` loading from `/_astro/`
- [ ] DevTools → Elements → confirm `body { font-family: "Geist Variable", … }` computed
- [ ] Hero: italic "Everywhere." renders in Instrument Serif (no gradient)
- [ ] Features section is a vertical editorial list (no card grid)
- [ ] Database marquee scrolls horizontally; pauses on hover; icons are visible 44–52px tiles
- [ ] Lighthouse a11y: contrast checks pass for all secondary text
- [ ] Touch-target audit: nav pill, footer links, modal close are ≥44×44
- [ ] `prefers-reduced-motion` disables the marquee + alien breathing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned hero section with updated animations and button interactions
  * Refreshed features section layout and visual styling
  * Updated screenshots gallery presentation with parallax adjustments
  * Implemented continuous scrolling database marquee
  * Switched to dark theme with refreshed color palette

* **Chores**
  * Added new typography fonts (Geist, Geist Mono, Instrument Serif)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Comprehensive editorial redesign of the landing page: self-hosted Geist/Instrument Serif fonts, token-driven dark palette, `<symbol>`/`<use>` deduplication for the alien SVG, CSS marquee replacing the spotlight grid, and per-row `whileInView` animations replacing per-card `useScroll` listeners.
- A P1 logic bug in `features-section.tsx`: `accent.replace(")", " / 0.08)")` targets the first `)` inside `var()` rather than the outer `hsl()` closing paren, producing invalid CSS for features 1 and 4 and silently rendering their icon containers with no background or border colour.
- Two accessibility gaps in `database-marquee.tsx`: the duplicated track items (for the infinite loop) are all exposed to screen readers as `listitem` nodes, and `alt=""` is passed to SVG icon components where `aria-hidden="true"` is the correct pattern.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is — P1 renders two feature icon containers transparently due to a string-replace bug.

One P1 (invalid CSS from wrong `.replace()` target silently drops background/border on features 1 and 4) caps the score at 4, and the compound AT-exposure issue in the marquee pulls it one notch lower.

`apps/landing/src/components/features-section.tsx` (P1 string replace bug) and `apps/landing/src/components/database-marquee.tsx` (duplicate AT exposure + SVG alt attribute).
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/landing/src/components/features-section.tsx | Editorial row layout with a P1 bug: `.replace(")", ...)` targets the wrong `)` in `hsl(var(--alien-1))`, silently producing invalid CSS for features 1 and 4 icon backgrounds. |
| apps/landing/src/components/database-marquee.tsx | Spotlight grid replaced with a CSS infinite-scroll marquee; duplicate track items and missing `aria-hidden` on SVG icons are accessibility gaps. |
| apps/landing/src/components/hero-section.tsx | Refactored hero with `<symbol>`/`<use>` deduplication for the alien paths, `client:idle`, and magnetic CTA buttons. No issues found. |
| apps/landing/src/styles/global.css | Token-driven dark palette, `prefers-reduced-motion` global reset, editorial `.eyebrow` and `.font-display` utilities added. Looks correct. |
| apps/landing/src/layouts/Layout.astro | Self-hosted font imports via `@fontsource-variable`, Geist feature settings in `<style is:global>`, skip-to-content link. No issues found. |
| apps/landing/src/components/screenshots-section.tsx | `grid-cols-2 lg:grid-cols-4` grid, 44×44 close button, focus-trap modal, `muted-foreground` label color. No issues found. |
| apps/landing/tailwind.config.js | Adds `font-display` (Instrument Serif), updates `font-sans`/`font-mono` to Geist Variable families. Clean config addition. |
| apps/landing/package.json | Adds `@fontsource-variable/geist`, `@fontsource-variable/geist-mono`, and `@fontsource/instrument-serif` dependencies. Expected change. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Layout.astro
Imports Geist + Instrument Serif
via @fontsource-variable] --> B[index.astro
Assembles page sections]

    B --> C[HeroSection
Alien SVG via symbol+use
client:idle]
    B --> D[FeaturesSection
Editorial 12-col row list
whileInView per row]
    B --> E[ScreenshotsSection
Parallax grid
Focus-trapped modal]
    B --> F[DatabaseMarquee
CSS infinite scroll
pause-on-hover]

    D -->|accent color| G{startsWith hsl?}
    G -->|Yes — BROKEN| H[replace first paren
→ invalid CSS]
    G -->|No — OK| I[hex + opacity suffix]

    F --> J[track = databases x2
12 listitem nodes exposed to AT]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Flanding%2Fsrc%2Fcomponents%2Ffeatures-section.tsx%3A59-60%0A**HSL%20alpha%20injection%20targets%20wrong%20%60%29%60%20%E2%80%94%20produces%20invalid%20CSS**%0A%0A%60String.prototype.replace%28%22%29%22%2C%20...%29%60%20replaces%20only%20the%20*first*%20occurrence.%20For%20%60%22hsl%28var%28--alien-1%29%29%22%60%20the%20first%20%60%29%60%20is%20the%20one%20closing%20the%20inner%20%60var%28%29%60%2C%20so%20the%20result%20is%20%60%22hsl%28var%28--alien-1%20%2F%200.08%29%29%22%60%20%E2%80%94%20a%20reference%20to%20the%20non-existent%20custom%20property%20%60--alien-1%20%2F%200.08%60.%20Browsers%20treat%20this%20as%20invalid%20and%20fall%20back%20to%20%60transparent%60%2C%20so%20feature%20rows%201%20and%204%20silently%20render%20with%20no%20icon%20background%20or%20border%20colour.%0A%0AUse%20%60replace%28%2F%5C%29%24%2F%2C%20...%29%60%20to%20target%20only%20the%20last%20%60%29%60%3A%0A%0A%60%60%60suggestion%0A%09%09%09%09%09background%3A%20%60%24%7Baccent.startsWith%28%22hsl%22%29%20%3F%20accent.replace%28%2F%5C%29%24%2F%2C%20%22%20%2F%200.08%29%22%29%20%3A%20%60%24%7Baccent%7D15%60%7D%60%2C%0A%09%09%09%09%09borderColor%3A%20%60%24%7Baccent.startsWith%28%22hsl%22%29%20%3F%20accent.replace%28%2F%5C%29%24%2F%2C%20%22%20%2F%200.18%29%22%29%20%3A%20%60%24%7Baccent%7D26%60%7D%60%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Flanding%2Fsrc%2Fcomponents%2Fdatabase-marquee.tsx%3A42-58%0A**Duplicate%20items%20exposed%20to%20screen%20readers**%0A%0A%60track%60%20is%20%60%5B...databases%2C%20...databases%5D%60%20%2812%20entries%29%2C%20and%20the%20container%20explicitly%20sets%20%60aria-hidden%3D%22false%22%60%20%28which%20is%20the%20default%2C%20no-op%29.%20A%20screen%20reader%20will%20announce%20all%2012%20%60listitem%60%20nodes%20%E2%80%94%20each%20database%20name%20twice%20%E2%80%94%20with%20no%20indication%20that%20the%20second%20set%20is%20a%20visual%20loop%20artefact.%20The%20duplicate%20half%20should%20be%20hidden%20from%20AT.%20Consider%20setting%20%60aria-hidden%3D%22true%22%60%20on%20items%20where%20%60i%20%3E%3D%20databases.length%60%2C%20or%20marking%20the%20whole%20animating%20track%20as%20%60aria-hidden%3D%22true%22%60%20and%20placing%20a%20single%20static%20visually-hidden%20list%20for%20AT.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Flanding%2Fsrc%2Fcomponents%2Fdatabase-marquee.tsx%3A46-52%0A**%60alt%3D%22%22%60%20has%20no%20effect%20on%20SVG%20icon%20components**%0A%0ASVG%20elements%20don't%20accept%20an%20%60alt%60%20attribute%3B%20it%20will%20be%20silently%20ignored%20by%20the%20browser.%20The%20previous%20code%20used%20%60aria-hidden%3D%22true%22%60%2C%20which%20is%20the%20correct%20pattern%20for%20decorative%20icons%20whose%20name%20is%20already%20conveyed%20by%20the%20adjacent%20text%20label.%20Consider%20restoring%20%60aria-hidden%3D%22true%22%60%20here.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09%09%3Cdb.icon%0A%09%09%09%09%09%09%09className%3D%22w-7%20h-7%20md%3Aw-8%20md%3Ah-8%20brightness-0%20invert%20opacity-70%22%0A%09%09%09%09%09%09%09width%3D%7B32%7D%0A%09%09%09%09%09%09%09height%3D%7B32%7D%0A%09%09%09%09%09%09%09aria-hidden%3D%22true%22%0A%09%09%09%09%09%09%2F%3E%0A%60%60%60%0A%0A&repo=arioberek%2Fcosmq&pr=20&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arioberek%2Fcosmq%22%20on%20the%20existing%20branch%20%22refactor%2Flanding-design-pass%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Flanding-design-pass%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Flanding%2Fsrc%2Fcomponents%2Ffeatures-section.tsx%3A59-60%0A**HSL%20alpha%20injection%20targets%20wrong%20%60%29%60%20%E2%80%94%20produces%20invalid%20CSS**%0A%0A%60String.prototype.replace%28%22%29%22%2C%20...%29%60%20replaces%20only%20the%20*first*%20occurrence.%20For%20%60%22hsl%28var%28--alien-1%29%29%22%60%20the%20first%20%60%29%60%20is%20the%20one%20closing%20the%20inner%20%60var%28%29%60%2C%20so%20the%20result%20is%20%60%22hsl%28var%28--alien-1%20%2F%200.08%29%29%22%60%20%E2%80%94%20a%20reference%20to%20the%20non-existent%20custom%20property%20%60--alien-1%20%2F%200.08%60.%20Browsers%20treat%20this%20as%20invalid%20and%20fall%20back%20to%20%60transparent%60%2C%20so%20feature%20rows%201%20and%204%20silently%20render%20with%20no%20icon%20background%20or%20border%20colour.%0A%0AUse%20%60replace%28%2F%5C%29%24%2F%2C%20...%29%60%20to%20target%20only%20the%20last%20%60%29%60%3A%0A%0A%60%60%60suggestion%0A%09%09%09%09%09background%3A%20%60%24%7Baccent.startsWith%28%22hsl%22%29%20%3F%20accent.replace%28%2F%5C%29%24%2F%2C%20%22%20%2F%200.08%29%22%29%20%3A%20%60%24%7Baccent%7D15%60%7D%60%2C%0A%09%09%09%09%09borderColor%3A%20%60%24%7Baccent.startsWith%28%22hsl%22%29%20%3F%20accent.replace%28%2F%5C%29%24%2F%2C%20%22%20%2F%200.18%29%22%29%20%3A%20%60%24%7Baccent%7D26%60%7D%60%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Flanding%2Fsrc%2Fcomponents%2Fdatabase-marquee.tsx%3A42-58%0A**Duplicate%20items%20exposed%20to%20screen%20readers**%0A%0A%60track%60%20is%20%60%5B...databases%2C%20...databases%5D%60%20%2812%20entries%29%2C%20and%20the%20container%20explicitly%20sets%20%60aria-hidden%3D%22false%22%60%20%28which%20is%20the%20default%2C%20no-op%29.%20A%20screen%20reader%20will%20announce%20all%2012%20%60listitem%60%20nodes%20%E2%80%94%20each%20database%20name%20twice%20%E2%80%94%20with%20no%20indication%20that%20the%20second%20set%20is%20a%20visual%20loop%20artefact.%20The%20duplicate%20half%20should%20be%20hidden%20from%20AT.%20Consider%20setting%20%60aria-hidden%3D%22true%22%60%20on%20items%20where%20%60i%20%3E%3D%20databases.length%60%2C%20or%20marking%20the%20whole%20animating%20track%20as%20%60aria-hidden%3D%22true%22%60%20and%20placing%20a%20single%20static%20visually-hidden%20list%20for%20AT.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Flanding%2Fsrc%2Fcomponents%2Fdatabase-marquee.tsx%3A46-52%0A**%60alt%3D%22%22%60%20has%20no%20effect%20on%20SVG%20icon%20components**%0A%0ASVG%20elements%20don't%20accept%20an%20%60alt%60%20attribute%3B%20it%20will%20be%20silently%20ignored%20by%20the%20browser.%20The%20previous%20code%20used%20%60aria-hidden%3D%22true%22%60%2C%20which%20is%20the%20correct%20pattern%20for%20decorative%20icons%20whose%20name%20is%20already%20conveyed%20by%20the%20adjacent%20text%20label.%20Consider%20restoring%20%60aria-hidden%3D%22true%22%60%20here.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09%09%3Cdb.icon%0A%09%09%09%09%09%09%09className%3D%22w-7%20h-7%20md%3Aw-8%20md%3Ah-8%20brightness-0%20invert%20opacity-70%22%0A%09%09%09%09%09%09%09width%3D%7B32%7D%0A%09%09%09%09%09%09%09height%3D%7B32%7D%0A%09%09%09%09%09%09%09aria-hidden%3D%22true%22%0A%09%09%09%09%09%09%2F%3E%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(landing): editorial design pass..."](https://github.com/arioberek/cosmq/commit/d4f110f0c5d68aa8dab531bf4eca8bf37b1e7973) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31406394)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->